### PR TITLE
fix: preserve predictive return-home lifecycle across ``delayed commits and launcher OPEN reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,11 @@ Return-to-home rules:
   assume delivery order. Retain only the current generation's latest start/progress and at
   most one terminal action, consume them exactly once when the runner arrives, and discard
   them even when its targets are invalid.
+- Authenticate an unbound standard commit against the latest accepted DOWN. Once the exact
+  current runner session exists, bind a delayed commit against that session's immutable input
+  identity even if a newer accepted DOWN has replaced the process-global latest identity.
+  Preserve arbiter-generation, task, transition, attempt-order, and session ownership checks;
+  a current session must not authenticate a signal that fails its exact frozen identity.
 - Follow the platform `removeDepartTargetFromMotion()` split: use the `BackMotionEvent`
   departing target when the flag is false and the runner closing target when it is true.
   Use the platform `BackProgressAnimator` for smoothed progress and drive the same Xiaomi
@@ -331,6 +336,12 @@ Return-to-home rules:
 - For one animation and `animTo` epoch, preserve the first exact pre-clear finish snapshot.
   A duplicate `StateManager` end callback after element/target cleanup must not overwrite
   that terminal identity or keep the Shell runner alive.
+- When an exact cancelled `APP_TO_APP` preview spring is reused in place as launcher
+  `OPEN_FROM_HOME` before cancellation cleanup completes, finish the old return-home owner at
+  the verified main-Looper StateManager, element, animation, and configured-epoch boundary
+  without restoring its Surface, then let launcher OPEN adopt that spring. If an overlapping
+  runner is explicitly rejected while an existing owner remains, discard that runner's
+  remaining callback sequence exactly once; never let it seed the next runner.
 - Preserve Xiaomi's parallel CLOSE-to-OPEN path when an icon is clicked before CLOSE ends.
   Finish the old Shell runner only after Xiaomi cancels the old application Surface and
   accepts its `setToOld` boundary, before the new OPEN starts; do not cancel or wait for the

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
@@ -1940,19 +1940,27 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 return result;
             }
 
-            Object controller = miuiHomeOpenBreakController;
-            if (controller == null) {
-                log(Log.WARN, TAG, "Cannot restore reused CLOSE-to-OPEN break state"
-                        + ", controller=null"
-                        + ", currentAnimType=" + currentAnimType
-                        + ", windowElement=" + shortObject(openingElement));
-                return result;
-            }
             Object animationIdentity = invokeAnyMethod(
                     openingElement, "getAnimSymbol", new Object[0]);
             if (animationIdentity == null) {
                 log(Log.WARN, TAG, "Cannot identify reused CLOSE-to-OPEN animation"
                         + ", animationIdentity=null"
+                        + ", currentAnimType=" + currentAnimType
+                        + ", windowElement=" + shortObject(openingElement));
+                return result;
+            }
+
+            MiuiHomeReturnHomeController returnHomeController =
+                    miuiHomeReturnHomeController;
+            if (returnHomeController != null) {
+                returnHomeController.finishUnifiedCancelForReusedOpen(
+                        stateManager, openingElement, animationIdentity);
+            }
+
+            Object controller = miuiHomeOpenBreakController;
+            if (controller == null) {
+                log(Log.WARN, TAG, "Cannot restore reused CLOSE-to-OPEN break state"
+                        + ", controller=null"
                         + ", currentAnimType=" + currentAnimType
                         + ", windowElement=" + shortObject(openingElement));
                 return result;

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeRuntime.java
@@ -136,6 +136,7 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
         protected BackMotionEvent pendingStartEvent;
         protected BackMotionEvent pendingProgressEvent;
         protected int pendingTerminalAction = RETURN_HOME_TERMINAL_NONE;
+        protected boolean discardRejectedRunnerCallback;
         protected Constructor<?> nativeTargetSetConstructor;
         protected Constructor<?> nativeWindowAnimParamsConstructor;
         protected Constructor<?> nativeRectFParamsConstructor;
@@ -194,6 +195,7 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
                 attached = false;
                 invalidatePendingFreshOpen("deferredControllerReplacement:" + reason);
                 clearPendingCallbackState();
+                discardRejectedRunnerCallback = false;
                 pendingStandardCommitSignal.set(null);
                 pendingUnifiedNativeFinishDispatches.clear();
             }
@@ -260,6 +262,7 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
                         shouldRestorePreview(session));
             }
             clearPendingCallbackState();
+            discardRejectedRunnerCallback = false;
             pendingStandardCommitSignal.set(null);
             pendingUnifiedNativeFinishDispatches.clear();
             if (clearShell && !shellBinderDead
@@ -291,8 +294,12 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
             // A callback start is the generation boundary even if the preceding runner never
             // arrived. Do not let its last progress sample bleed into this gesture.
             clearPendingCallbackState();
+            if (discardRejectedRunnerCallback) {
+                releaseBackMotionEventTarget(event);
+                return;
+            }
             ReturnHomeSession session = currentSession;
-            if (session == null) {
+            if (session == null || session.progressFrozen) {
                 pendingStartEvent = event;
                 return;
             }
@@ -303,8 +310,11 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
             if (!attached || event == null) {
                 return;
             }
+            if (discardRejectedRunnerCallback) {
+                return;
+            }
             ReturnHomeSession session = currentSession;
-            if (session == null) {
+            if (session == null || session.progressFrozen) {
                 pendingProgressEvent = event;
                 return;
             }
@@ -319,8 +329,15 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
         }
 
         void onBackCancelled() {
+            if (discardRejectedRunnerCallback) {
+                discardRejectedRunnerCallback = false;
+                clearPendingCallbackState();
+                log(Log.INFO, TAG,
+                        "Discarded cancel callback for rejected return-home runner");
+                return;
+            }
             ReturnHomeSession session = currentSession;
-            if (session == null) {
+            if (session == null || session.progressFrozen) {
                 pendingTerminalAction = RETURN_HOME_TERMINAL_CANCEL;
                 return;
             }
@@ -329,8 +346,15 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
         }
 
         void onBackInvoked() {
+            if (discardRejectedRunnerCallback) {
+                discardRejectedRunnerCallback = false;
+                clearPendingCallbackState();
+                log(Log.INFO, TAG,
+                        "Discarded invoke callback for rejected return-home runner");
+                return;
+            }
             ReturnHomeSession session = currentSession;
-            if (session == null) {
+            if (session == null || session.progressFrozen) {
                 pendingTerminalAction = RETURN_HOME_TERMINAL_INVOKE;
                 log(Log.INFO, TAG, "Return-to-home invoke waiting for remote targets");
                 return;
@@ -361,6 +385,8 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
                         startUnifiedNativeCancel(
                                 previous, "supersededRunner");
                     }
+                    discardRejectedRunnerCallback =
+                            pendingTerminalAction == RETURN_HOME_TERMINAL_NONE;
                     clearPendingCallbackState();
                     discardMatchingUnboundStandardSignal(
                             miuiHomeAcceptedInputIdentity.get(),
@@ -8642,6 +8668,43 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
                 return;
             }
             consumeUnifiedNativeFinishSnapshot(session, reason);
+        }
+
+        void finishUnifiedCancelForReusedOpen(
+                Object stateManager, Object windowElement,
+                Object animationIdentity) {
+            ReturnHomeSession session = currentSession;
+            UnifiedNativeConfiguredAnimToSnapshot configured = session == null
+                    ? null : session.unifiedNativeConfiguredAnimTo.get();
+            if (Looper.myLooper() != Looper.getMainLooper()
+                    || session == null || session.finished.get() != 0
+                    || session.unifiedNativeCleanupVerified
+                    || session.stateManager != stateManager
+                    || session.nativeWindowElement != windowElement
+                    || session.unifiedNativeAnimationIdentity != animationIdentity
+                    || session.nativeHandoffStarted
+                    || session.nativeAnimationStarted
+                    || session.unifiedNativeCommitPending
+                    || !isExactUnifiedConfiguredAnimTo(
+                    session, configured, windowElement,
+                    animationIdentity, "APP_TO_APP")) {
+                return;
+            }
+            Runnable timeout = session.unifiedNativeCancelTimeout;
+            if (timeout != null) {
+                handler.removeCallbacks(timeout);
+            }
+            session.unifiedNativeCancelTimeout = null;
+            session.unifiedNativeCancelPending = false;
+            session.unifiedNativeCancelRetargeted = false;
+            session.unifiedNativeCleanupVerified = true;
+            log(Log.INFO, TAG,
+                    "Finished cancelled return-home owner at reused launcher OPEN"
+                            + ", generation=" + session.generation
+                            + ", animToEpoch=" + configured.animToEpoch
+                            + ", animationIdentity="
+                            + shortObject(animationIdentity));
+            finishSession(session, "cancelReusedForLauncherOpen", false);
         }
 
         protected boolean isStandardSingleTaskReturnHome(ReturnHomeSession session) {

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeRuntime.java
@@ -8874,11 +8874,15 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
                 handler.post(() -> onStandardShellReturnHomeCommit(signal));
                 return;
             }
+            ReturnHomeSession activeSession = currentSession;
+            boolean bindNow = standardSignalMatchesSession(
+                    signal, activeSession);
             MiuiHomeAcceptedInputToken latestInput =
                     miuiHomeAcceptedInputIdentity.get();
+            boolean latestInputMatches = signal.matchesInput(latestInput);
             if (signal.arbiterGeneration
                     != miuiHomeSystemUiInputArbiterGeneration
-                    || !signal.matchesInput(latestInput)) {
+                    || (!latestInputMatches && !bindNow)) {
                 log(Log.WARN, TAG,
                         "Rejected standard commit without current accepted DOWN"
                                 + ", attempt=" + signal.attempt
@@ -8899,9 +8903,6 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
                 return;
             }
             lastStandardCommitSignalAttempt = signal.attempt;
-            ReturnHomeSession activeSession = currentSession;
-            boolean bindNow = standardSignalMatchesSession(
-                    signal, activeSession);
             StandardReturnHomeCommitSignal boundSignal = bindNow
                     ? signal.bindToLauncherSession(
                     activeSession.generation)
@@ -8933,6 +8934,10 @@ public abstract class MiuiHomeReturnHomeRuntime extends SystemUiHookRuntime {
                             + ", arbiterGeneration="
                             + boundSignal.arbiterGeneration
                             + ", eventId=" + boundSignal.eventId
+                            + ", inputIdentitySource="
+                            + (latestInputMatches ? "latest" : "activeSession")
+                            + ", latestEventId="
+                            + (latestInput == null ? 0 : latestInput.eventId)
                             + ", launcherGeneration="
                             + boundSignal.launcherSessionGeneration);
             if (bindNow) {


### PR DESCRIPTION
“提高模块稳定性，优化模块流畅度”