### PR TITLE
feat: add HyperOS-style back arrow, gesture haptics, slide-back anim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,9 +130,9 @@ Hot-reload rules:
   forge Taskbar initialization, or write lifecycle booleans directly. Reconcile ownership after
   default-display NavigationBar create/remove and navigation-mode changes; a real NavigationBar
   or Taskbar owns the native listener lifecycle whenever present.
-- In `onHotReloading(...)`, detach module-owned input monitors, unregister receivers, and
-  invalidate pending snapshots/attempts before saving only the state that is explicitly
-  restored. In `onHotReloaded(...)`, replace or neutralize every old hook and restore state
+- In `onHotReloading(...)`, detach module-owned input monitors and indicator overlay
+  windows, unregister receivers, and invalidate pending snapshots/attempts before saving
+  only the state that is explicitly restored. In `onHotReloaded(...)`, replace or neutralize every old hook and restore state
   without duplicating monitors, receivers, or callbacks.
 - When restoring MiuiHome from an older non-touchable Stub build, clear the existing
   `FLAG_NOT_TOUCHABLE` in WMS on each Stub's View owner Looper, request layout and internal
@@ -270,9 +270,49 @@ Remote-animation rules:
   reflection uncertainty, and every other null-navigation path still cancel and clean with
   `finishBackNavigation(false)` without a fallback key.
 - Do not swap closing/entering targets or transform leashes, and do not force
-  alpha/visibility/layer order without new evidence for that exact fault.
-- Use SystemUI's native `BackPanelController` indicator. Avoid Xiaomi/MiuiHome arrow paths
-  and custom-drawn fallbacks except for native-indicator attachment diagnostics.
+  alpha/visibility/layer order without new evidence for that exact fault. The only
+  exception is the `hyperos_slide_back_animation` switch (default off): it restyles the
+  native cross-activity animation's geometry mapping in place — a full-width closing
+  slide mapping the spring-smoothed delivered progress linearly (no gesture
+  interpolator: finger-following but always animated, cancel riding the same spring),
+  no scale and no vertical follow, quarter-width entering parallax at alpha 0.9 -> 1, a
+  cubic ease-out ~400ms commit settle, and the cross-task registry entry reusing the
+  same hooked animation. The per-frame driver replaces the ProgressCallback the
+  animation registers on its own framework BackProgressAnimator, because R8 inlines the
+  private progress method. At commit the subclass rewrites the target rects to its 0.9
+  card pose, so the post-commit hook restores the full slide-out destination; the
+  committed close transition's own reparent (native handleCloseTransition) already keeps
+  the container pixels on the runner leashes. The revealed lower layer follows the finger:
+  its dim scrim scales with drag progress (not only at release) and its corner radius is
+  cleared (only the sliding top card is rounded). Targets, scrim, letterboxes, corner radius, the
+  progress/commit/cancel lifecycle, and `finishAnimation()` stay native; any hook or
+  reflection failure falls back to the stock AOSP animation for that gesture.
+  `TYPE_RETURN_TO_HOME` and `TYPE_CALLBACK` are never restyled.
+- Keep SystemUI's native `BackPanelController` as the sole indicator state owner: it
+  receives every claimed event and owns thresholds, release state, and haptics. The
+  optional HyperOS-style skin (`hyperos_indicator_style` remote preference, default off)
+  only suppresses the native panel's View alpha and draws a module-owned visual-only port
+  of MiuiHome's `GestureBackArrowView` in a non-touchable SystemUI overlay window, with
+  bitmaps loaded at runtime from `com.miui.home` resources. The skin follows Xiaomi's
+  native timing: nothing is drawn before the 20px horizontal, vertical-dominance intent
+  threshold, and the arrow icon lights only when the official 180px rule and the native
+  panel's ACTIVE/FLUNG/COMMITTED state both hold, so a lit arrow always matches the real
+  commit decision. It adds no input handling, and any preference, resource, window, or
+  panel-hide failure fails closed to the visible native panel. Haptics default to the
+  native BackPanel threshold feedback; the optional `hyperos_indicator_haptics` switch
+  (requires the skin) instead reproduces Xiaomi's two-stage haptics through the framework
+  `miui.util.HapticFeedbackUtil` — ready-back on uncancelled arrow fade-in completion (ext
+  effect 162, or 0 on `sys.haptic.version=2.0`), hand-up only on a panel-committed release
+  under Xiaomi's doFeedBack rule (non-V2 slow release or unfinished ready-back), with the
+  linear 140ms hand-up blocker — and suppresses only the hidden panel view's
+  `isHapticFeedbackEnabled` so no other SystemUI haptics change. The additional
+  `hyperos_indicator_haptics_enhanced` switch (requires the haptics switch) strengthens
+  the release stage: every panel-committed release plays hand-up, V2 devices use ext
+  effect 1 for hand-up instead of 0, and the 140ms blocker also applies to V2.
+  Unsupported effects or any failure in this chain fails closed to the native BackPanel
+  haptics. Avoid
+  MiuiHome-process arrow paths and any other custom-drawn fallback except for
+  native-indicator attachment diagnostics.
 - Restore `TYPE_RETURN_TO_HOME` through the standard Shell-to-launcher callback/runner
   registration. The confirmed entry is the Shell `IBackAnimation` binder in
   `LauncherProxyService`'s external-interface bundle; make MiuiHome consume that standard

--- a/app/src/main/java/dev/codex/miuibackgesturehook/PredictiveBackPreferences.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/PredictiveBackPreferences.java
@@ -3,6 +3,16 @@ package dev.codex.miuibackgesturehook;
 public final class PredictiveBackPreferences {
     public static final String GROUP = "predictive_back_opt_in";
     public static final String KEY_PACKAGES = "packages";
+    public static final String KEY_HYPEROS_INDICATOR = "hyperos_indicator_style";
+    public static final boolean DEFAULT_HYPEROS_INDICATOR = false;
+    public static final String KEY_HYPEROS_HAPTICS = "hyperos_indicator_haptics";
+    public static final boolean DEFAULT_HYPEROS_HAPTICS = false;
+    public static final String KEY_HYPEROS_HAPTICS_ENHANCED =
+            "hyperos_indicator_haptics_enhanced";
+    public static final boolean DEFAULT_HYPEROS_HAPTICS_ENHANCED = false;
+    public static final String KEY_HYPEROS_SLIDE_ANIMATION =
+            "hyperos_slide_back_animation";
+    public static final boolean DEFAULT_HYPEROS_SLIDE_ANIMATION = false;
 
     private PredictiveBackPreferences() {
     }

--- a/app/src/main/java/dev/codex/miuibackgesturehook/PredictiveBackSettingsActivity.kt
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/PredictiveBackSettingsActivity.kt
@@ -12,7 +12,6 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.LruCache
-import android.util.Printer
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -25,8 +24,8 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -74,9 +73,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -85,7 +84,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.core.graphics.drawable.toBitmap
 import io.github.libxposed.service.XposedService
-import java.util.HashSet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -125,6 +123,7 @@ import top.yukonga.miuix.kmp.theme.lightColorScheme
 import top.yukonga.miuix.kmp.utils.overScrollVertical
 import top.yukonga.miuix.kmp.utils.scrollEndHaptic
 import top.yukonga.miuix.kmp.window.WindowListPopup
+import kotlin.time.Duration.Companion.milliseconds
 
 class PredictiveBackSettingsActivity :
     ComponentActivity(),
@@ -260,13 +259,21 @@ private fun PredictiveBackSettingsScreen(
     var saveError by remember { mutableStateOf<String?>(null) }
     var localWriteGeneration by remember { mutableStateOf(0L) }
     var confirmedPackages by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var hyperOsIndicator by remember { mutableStateOf(false) }
+    var confirmedHyperOsIndicator by remember { mutableStateOf(false) }
+    var hyperOsHaptics by remember { mutableStateOf(false) }
+    var confirmedHyperOsHaptics by remember { mutableStateOf(false) }
+    var hyperOsHapticsEnhanced by remember { mutableStateOf(false) }
+    var confirmedHyperOsHapticsEnhanced by remember { mutableStateOf(false) }
+    var hyperOsSlideAnimation by remember { mutableStateOf(false) }
+    var confirmedHyperOsSlideAnimation by remember { mutableStateOf(false) }
     val writeMutex = remember(preferences) { Mutex() }
     val lazyListState = rememberLazyListState()
     val scrollBehavior = MiuixScrollBehavior()
     val showFloating by remember {
         derivedStateOf {
             lazyListState.firstVisibleItemIndex > 0 ||
-                lazyListState.firstVisibleItemScrollOffset > 0
+                    lazyListState.firstVisibleItemScrollOffset > 0
         }
     }
     val layoutDirection = LocalLayoutDirection.current
@@ -281,7 +288,7 @@ private fun PredictiveBackSettingsScreen(
         appsError = null
         try {
             if (refreshingExistingList) {
-                delay(1_500)
+                delay(1_500.milliseconds)
             }
             val loaded = withContext(Dispatchers.IO) {
                 loadLaunchableApps(
@@ -305,6 +312,14 @@ private fun PredictiveBackSettingsScreen(
         saveError = null
         localWriteGeneration = 0L
         confirmedPackages = emptySet()
+        hyperOsIndicator = false
+        confirmedHyperOsIndicator = false
+        hyperOsHaptics = false
+        confirmedHyperOsHaptics = false
+        hyperOsHapticsEnhanced = false
+        confirmedHyperOsHapticsEnhanced = false
+        hyperOsSlideAnimation = false
+        confirmedHyperOsSlideAnimation = false
         if (!serviceStateObserved) {
             configurationLoading = true
             return@LaunchedEffect
@@ -321,11 +336,37 @@ private fun PredictiveBackSettingsScreen(
                     .getStringSet(PredictiveBackPreferences.KEY_PACKAGES, emptySet())
                     .orEmpty()
                     .filterTo(HashSet()) { it.isNotBlank() }
-                remotePreferences to packages.toSet()
+                val hyperOsFlags = booleanArrayOf(
+                    remotePreferences.getBoolean(
+                        PredictiveBackPreferences.KEY_HYPEROS_INDICATOR,
+                        PredictiveBackPreferences.DEFAULT_HYPEROS_INDICATOR,
+                    ),
+                    remotePreferences.getBoolean(
+                        PredictiveBackPreferences.KEY_HYPEROS_HAPTICS,
+                        PredictiveBackPreferences.DEFAULT_HYPEROS_HAPTICS,
+                    ),
+                    remotePreferences.getBoolean(
+                        PredictiveBackPreferences.KEY_HYPEROS_HAPTICS_ENHANCED,
+                        PredictiveBackPreferences.DEFAULT_HYPEROS_HAPTICS_ENHANCED,
+                    ),
+                    remotePreferences.getBoolean(
+                        PredictiveBackPreferences.KEY_HYPEROS_SLIDE_ANIMATION,
+                        PredictiveBackPreferences.DEFAULT_HYPEROS_SLIDE_ANIMATION,
+                    ),
+                )
+                Triple(remotePreferences, packages.toSet(), hyperOsFlags)
             }
             preferences = loaded.first
             selectedPackages = loaded.second
             confirmedPackages = loaded.second
+            hyperOsIndicator = loaded.third[0]
+            confirmedHyperOsIndicator = loaded.third[0]
+            hyperOsHaptics = loaded.third[1]
+            confirmedHyperOsHaptics = loaded.third[1]
+            hyperOsHapticsEnhanced = loaded.third[2]
+            confirmedHyperOsHapticsEnhanced = loaded.third[2]
+            hyperOsSlideAnimation = loaded.third[3]
+            confirmedHyperOsSlideAnimation = loaded.third[3]
         } catch (_: Throwable) {
             configurationError = configurationErrorMessage
         } finally {
@@ -374,8 +415,8 @@ private fun PredictiveBackSettingsScreen(
             .filter { app -> showSystemApps || !app.isSystem }
             .filter { app ->
                 query.isEmpty() ||
-                    app.label.contains(query, ignoreCase = true) ||
-                    app.packageName.contains(query, ignoreCase = true)
+                        app.label.contains(query, ignoreCase = true) ||
+                        app.packageName.contains(query, ignoreCase = true)
             }
             .toList()
 
@@ -410,18 +451,22 @@ private fun PredictiveBackSettingsScreen(
             text = serviceLoadingMessage,
             severity = CardSeverity.Info,
         )
+
         configurationError != null -> StatusCardMessage(
             text = configurationError.orEmpty(),
             severity = CardSeverity.Error,
         )
+
         saveError != null -> StatusCardMessage(
             text = saveError.orEmpty(),
             severity = CardSeverity.Error,
         )
+
         serviceStateObserved && service == null -> StatusCardMessage(
             text = serviceUnavailableMessage,
             severity = CardSeverity.Error,
         )
+
         else -> null
     }
     val persistSelection: (Set<String>) -> Unit = { requestedPackages ->
@@ -483,6 +528,89 @@ private fun PredictiveBackSettingsScreen(
                 }
             }
         }
+    }
+
+    val persistBooleanPreference: (
+        String,
+        Boolean,
+        (Boolean) -> Unit,
+        () -> Boolean,
+        (Boolean) -> Unit,
+    ) -> Unit = { key, requestedEnabled, setLocal, getConfirmed, setConfirmed ->
+        val activePreferences = preferences
+        if (activePreferences != null) {
+            setLocal(requestedEnabled)
+            saveError = null
+            scope.launch {
+                val saved = writeMutex.withLock {
+                    val fallbackEnabled = getConfirmed()
+                    val commitSucceeded = withContext(Dispatchers.IO) {
+                        val succeeded = try {
+                            activePreferences.edit()
+                                .putBoolean(key, requestedEnabled)
+                                .commit()
+                        } catch (_: Throwable) {
+                            false
+                        }
+                        if (!succeeded) {
+                            try {
+                                activePreferences.edit()
+                                    .putBoolean(key, fallbackEnabled)
+                                    .commit()
+                            } catch (_: Throwable) {
+                                // Same compensation as persistSelection: restore the cached
+                                // value even when the remote commit fails as well.
+                            }
+                        }
+                        succeeded
+                    }
+                    if (preferences === activePreferences && commitSucceeded) {
+                        setConfirmed(requestedEnabled)
+                    }
+                    commitSucceeded
+                }
+                if (preferences === activePreferences && !saved) {
+                    setLocal(getConfirmed())
+                    saveError = saveErrorMessage
+                }
+            }
+        }
+    }
+    val persistHyperOsIndicator: (Boolean) -> Unit = { requestedEnabled ->
+        persistBooleanPreference(
+            PredictiveBackPreferences.KEY_HYPEROS_INDICATOR,
+            requestedEnabled,
+            { hyperOsIndicator = it },
+            { confirmedHyperOsIndicator },
+            { confirmedHyperOsIndicator = it },
+        )
+    }
+    val persistHyperOsHaptics: (Boolean) -> Unit = { requestedEnabled ->
+        persistBooleanPreference(
+            PredictiveBackPreferences.KEY_HYPEROS_HAPTICS,
+            requestedEnabled,
+            { hyperOsHaptics = it },
+            { confirmedHyperOsHaptics },
+            { confirmedHyperOsHaptics = it },
+        )
+    }
+    val persistHyperOsHapticsEnhanced: (Boolean) -> Unit = { requestedEnabled ->
+        persistBooleanPreference(
+            PredictiveBackPreferences.KEY_HYPEROS_HAPTICS_ENHANCED,
+            requestedEnabled,
+            { hyperOsHapticsEnhanced = it },
+            { confirmedHyperOsHapticsEnhanced },
+            { confirmedHyperOsHapticsEnhanced = it },
+        )
+    }
+    val persistHyperOsSlideAnimation: (Boolean) -> Unit = { requestedEnabled ->
+        persistBooleanPreference(
+            PredictiveBackPreferences.KEY_HYPEROS_SLIDE_ANIMATION,
+            requestedEnabled,
+            { hyperOsSlideAnimation = it },
+            { confirmedHyperOsSlideAnimation },
+            { confirmedHyperOsSlideAnimation = it },
+        )
     }
 
     LaunchedEffect(preferences, applicationOptInPackages) {
@@ -688,6 +816,55 @@ private fun PredictiveBackSettingsScreen(
                     ) {
                         item(key = "compatibility_warning") {
                             WarningCard(
+                                modifier = Modifier
+                                    .padding(horizontal = 12.dp)
+                                    .padding(bottom = 8.dp),
+                            )
+                        }
+                        item(key = "hyperos_indicator") {
+                            HyperOsSwitchCard(
+                                titleRes = R.string.hyperos_indicator_title,
+                                summaryRes = R.string.hyperos_indicator_summary,
+                                checked = hyperOsIndicator,
+                                enabled = configurationEnabled,
+                                onToggle = persistHyperOsIndicator,
+                                modifier = Modifier
+                                    .padding(horizontal = 12.dp)
+                                    .padding(bottom = 8.dp),
+                            )
+                        }
+                        item(key = "hyperos_haptics") {
+                            HyperOsSwitchCard(
+                                titleRes = R.string.hyperos_haptics_title,
+                                summaryRes = R.string.hyperos_haptics_summary,
+                                checked = hyperOsHaptics,
+                                enabled = configurationEnabled && hyperOsIndicator,
+                                onToggle = persistHyperOsHaptics,
+                                modifier = Modifier
+                                    .padding(horizontal = 12.dp)
+                                    .padding(bottom = 8.dp),
+                            )
+                        }
+                        item(key = "hyperos_haptics_enhanced") {
+                            HyperOsSwitchCard(
+                                titleRes = R.string.hyperos_haptics_enhanced_title,
+                                summaryRes = R.string.hyperos_haptics_enhanced_summary,
+                                checked = hyperOsHapticsEnhanced,
+                                enabled = configurationEnabled && hyperOsIndicator &&
+                                        hyperOsHaptics,
+                                onToggle = persistHyperOsHapticsEnhanced,
+                                modifier = Modifier
+                                    .padding(horizontal = 12.dp)
+                                    .padding(bottom = 8.dp),
+                            )
+                        }
+                        item(key = "hyperos_slide_animation") {
+                            HyperOsSwitchCard(
+                                titleRes = R.string.hyperos_slide_animation_title,
+                                summaryRes = R.string.hyperos_slide_animation_summary,
+                                checked = hyperOsSlideAnimation,
+                                enabled = configurationEnabled,
+                                onToggle = persistHyperOsSlideAnimation,
                                 modifier = Modifier
                                     .padding(horizontal = 12.dp)
                                     .padding(bottom = 8.dp),
@@ -1050,6 +1227,56 @@ private fun EmptyRow() {
 }
 
 @Composable
+private fun HyperOsSwitchCard(
+    titleRes: Int,
+    summaryRes: Int,
+    checked: Boolean,
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(CardDefaults.CornerRadius))
+            .background(CardDefaults.defaultColors().color),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(
+                    enabled = enabled,
+                    onClick = { onToggle(!checked) },
+                )
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .weight(1f),
+            ) {
+                Text(
+                    text = stringResource(titleRes),
+                    style = MiuixTheme.textStyles.title4,
+                )
+                Text(
+                    text = stringResource(summaryRes),
+                    color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+                    style = MiuixTheme.textStyles.subtitle,
+                )
+            }
+            Switch(
+                modifier = Modifier.align(Alignment.CenterVertically),
+                checked = checked,
+                onCheckedChange = onToggle,
+                enabled = enabled,
+            )
+        }
+    }
+}
+
+@Composable
 private fun MiuixAppItem(
     modifier: Modifier = Modifier,
     app: AppEntry,
@@ -1204,8 +1431,8 @@ private fun loadLaunchableApps(
             launcherActivity = ComponentName(packageName, activityInfo.name),
             firstInstallTime = firstInstallTime,
             isSystem = applicationInfo.flags and (
-                ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP
-            ) != 0,
+                    ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP
+                    ) != 0,
             isAvailable = true,
         )
     }
@@ -1226,7 +1453,7 @@ private fun isApplicationPredictiveBackOptedIn(applicationInfo: ApplicationInfo)
     var dumpResult: Boolean? = null
     runCatching {
         applicationInfo.dump(
-            Printer { line ->
+            { line ->
                 if (line.startsWith(APPLICATION_PREDICTIVE_BACK_DUMP_PREFIX)) {
                     dumpResult = line
                         .removePrefix(APPLICATION_PREDICTIVE_BACK_DUMP_PREFIX)

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
@@ -106,13 +106,14 @@ public abstract class HookRuntimeCore extends XposedModule {
     protected abstract int readMotionEventDisplayId(MotionEvent event) throws Exception;
     protected abstract boolean isCurrentHeadlessNavBarLifecycle(
             Object edgeBackGestureHandler);
+    protected abstract boolean isHyperOsSlideAnimationEnabled();
     protected abstract Method requireExactDeclaredMethod(
             Class<?> owner, String methodName, String returnTypeName,
             String... parameterTypeNames) throws NoSuchMethodException;
 
     protected static final String TAG = "MiuiBackGestureHook";
     protected static final String BUILD_MARK =
-            "systemui-aosp-back-0.7.0-r51-activity-open-progress-handoff";
+            "systemui-aosp-back-0.7.2-r55-hyperos-slide-back-animation";
     protected static final String SYSTEM_UI = "com.android.systemui";
     protected static final String MIUI_HOME = "com.miui.home";
     protected static final String WINDOW_ON_BACK_INVOKED_DISPATCHER =
@@ -236,6 +237,10 @@ public abstract class HookRuntimeCore extends XposedModule {
             "com.miui.utils.configs.MiuiConfigs";
     protected static final String BACK_ANIMATION_CONTROLLER =
             "com.android.wm.shell.back.BackAnimationController";
+    protected static final String CROSS_ACTIVITY_BACK_ANIMATION =
+            "com.android.wm.shell.back.CrossActivityBackAnimation";
+    protected static final String DEFAULT_CROSS_ACTIVITY_BACK_ANIMATION =
+            "com.android.wm.shell.back.DefaultCrossActivityBackAnimation";
     protected static final String BACK_TRANSITION_HANDLER =
             "com.android.wm.shell.back.BackAnimationController$BackTransitionHandler";
     protected static final String DEFAULT_TRANSITION_HANDLER =
@@ -332,6 +337,8 @@ public abstract class HookRuntimeCore extends XposedModule {
     protected static final float EDGE_TOUCH_WIDTH_DP = 24.0f;
     protected static final float PILFER_THRESHOLD_DP = 8.0f;
     protected static final float TRIGGER_THRESHOLD_DP = 48.0f;
+    protected static final float MIUI_STYLE_SWIPE_START_PX = 20.0f;
+    protected static final float MIUI_STYLE_ARROW_SHOW_PX = 180.0f;
     protected static final float AOSP_PROGRESS_THRESHOLD_DP = 412.0f;
     protected static final float RETURN_HOME_MIN_WINDOW_SCALE = 0.85f;
     protected static final float RETURN_HOME_WINDOW_MARGIN_DP = 8.0f;
@@ -1113,10 +1120,17 @@ public abstract class HookRuntimeCore extends XposedModule {
             Object definitions = readField(registry, "mAnimationDefinition");
             Object defaultCrossActivity = readField(registry, "mDefaultCrossActivityAnimation");
             Object crossTask = readField(registry, "mCrossTaskAnimation");
+            // The slide style renders cross-task with the same hooked cross-activity
+            // animation so both in-app types share one full-width slide implementation.
+            boolean slideStyle = isHyperOsSlideAnimationEnabled()
+                    && defaultCrossActivity != null;
+            Object crossTaskAnimation = slideStyle ? defaultCrossActivity : crossTask;
             changed |= ensureRegistryRunner(definitions, TYPE_CROSS_ACTIVITY,
                     defaultCrossActivity, "crossActivity");
             changed |= ensureRegistryRunner(definitions, TYPE_CROSS_TASK,
-                    crossTask, "crossTask");
+                    crossTaskAnimation, slideStyle ? "crossTask->slide" : "crossTask");
+            changed |= reconcileCrossTaskRunner(definitions, defaultCrossActivity,
+                    crossTask, slideStyle);
             if (changed) {
                 invokeAnyMethod(registry, "updateSupportedAnimators", new Object[0]);
                 log(Log.INFO, TAG, "Restored AOSP registry definitions from " + source);
@@ -1124,6 +1138,46 @@ public abstract class HookRuntimeCore extends XposedModule {
         } catch (Throwable throwable) {
             log(Log.WARN, TAG, "Failed to restore AOSP registry definitions from " + source,
                     throwable);
+        }
+    }
+
+    /**
+     * Swaps an already-registered cross-task runner between the two module-managed
+     * animations when the slide-style preference changed. Only entries whose current
+     * value is the other module-known runner are replaced; anything else is foreign
+     * state and stays untouched.
+     */
+    protected boolean reconcileCrossTaskRunner(Object definitions,
+                                               Object defaultCrossActivity,
+                                               Object crossTask,
+                                               boolean slideStyle) {
+        if (!(definitions instanceof SparseArray<?>)) {
+            return false;
+        }
+        try {
+            SparseArray<?> entries = (SparseArray<?>) definitions;
+            int index = entries.indexOfKey(TYPE_CROSS_TASK);
+            if (index < 0) {
+                return false;
+            }
+            Object desiredAnimation = slideStyle ? defaultCrossActivity : crossTask;
+            Object otherAnimation = slideStyle ? crossTask : defaultCrossActivity;
+            if (desiredAnimation == null || otherAnimation == null) {
+                return false;
+            }
+            Object desired = invokeAnyMethod(desiredAnimation, "getRunner", new Object[0]);
+            Object other = invokeAnyMethod(otherAnimation, "getRunner", new Object[0]);
+            Object current = entries.valueAt(index);
+            if (desired == null || current == desired || current != other) {
+                return false;
+            }
+            invokeAnyMethod(definitions, "set",
+                    new Object[]{Integer.valueOf(TYPE_CROSS_TASK), desired});
+            log(Log.INFO, TAG, "Retargeted cross-task runner, slideStyle=" + slideStyle);
+            return true;
+        } catch (Throwable throwable) {
+            log(Log.WARN, TAG, "Failed to reconcile cross-task runner", throwable);
+            return false;
         }
     }
 

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/hotreload/HotReloadHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/hotreload/HotReloadHookRuntime.java
@@ -354,6 +354,18 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
             if (!oldHookIds.contains("systemui_back_prepare_reparent")) {
                 hookBackPrepareTransitionReparent(hotReloadClassLoader);
             }
+            if (!oldHookIds.contains("systemui_back_slide_start")
+                    || !oldHookIds.contains("systemui_back_slide_progress")
+                    || !oldHookIds.contains("systemui_back_slide_post_commit")
+                    || !oldHookIds.contains("systemui_back_slide_duration")
+                    || !oldHookIds.contains("systemui_back_slide_finish")) {
+                hookCrossActivitySlideAnimation(hotReloadClassLoader,
+                        !oldHookIds.contains("systemui_back_slide_start"),
+                        !oldHookIds.contains("systemui_back_slide_progress"),
+                        !oldHookIds.contains("systemui_back_slide_post_commit"),
+                        !oldHookIds.contains("systemui_back_slide_duration"),
+                        !oldHookIds.contains("systemui_back_slide_finish"));
+            }
             if (!backCommitCompositionHookReady) {
                 hookBackCommitComposition(hotReloadClassLoader);
             }
@@ -634,6 +646,16 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
                 return this::trackMiuiOpenCloseMerge;
             case "systemui_back_send_event_guard":
                 return this::guardDuplicateBackEvent;
+            case "systemui_back_slide_start":
+                return this::onCrossActivitySlideStart;
+            case "systemui_back_slide_progress":
+                return this::onCrossActivitySlideProgressRegistration;
+            case "systemui_back_slide_post_commit":
+                return this::onCrossActivitySlidePostCommit;
+            case "systemui_back_slide_duration":
+                return this::onCrossActivitySlideDuration;
+            case "systemui_back_slide_finish":
+                return this::onCrossActivitySlideFinish;
             case "systemui_back_prepare_reparent":
                 return this::correctPredictiveBackPrepareReparent;
             case "systemui_back_commit_composition":

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/MiuiHapticFeedbackHelper.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/MiuiHapticFeedbackHelper.java
@@ -1,0 +1,154 @@
+package dev.codex.miuibackgesturehook.hooks.systemui;
+
+import android.content.Context;
+import android.os.SystemClock;
+import android.util.Log;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Reproduces MiuiHome's two-stage back gesture haptics inside SystemUI through the
+ * framework {@code miui.util.HapticFeedbackUtil} (boot classpath on MIUI/HyperOS).
+ *
+ * <p>Mirrors {@code HapticFeedbackCompatLinear}/{@code HapticFeedbackCompatV2}:
+ * <ul>
+ *   <li>ready-back (arrow fade-in complete): ext effect 162 on linear-motor devices,
+ *       effect 0 on {@code sys.haptic.version=2.0} devices; arms a 140ms blocker on
+ *       linear devices only.</li>
+ *   <li>hand-up (committed release): ext effect 163 / 0, skipped on linear devices
+ *       within 140ms of ready-back.</li>
+ * </ul>
+ * Support requires {@code isSupportExtHapticFeedback(162) && (163)} exactly like
+ * Xiaomi's {@code isSupportEffectGestureBackLinear()}; anything else reports
+ * unsupported so callers keep the native AOSP panel haptics.
+ */
+final class MiuiHapticFeedbackHelper {
+
+    private static final int EFFECT_GESTURE_READY_BACK_LINEAR = 162;
+    private static final int EFFECT_GESTURE_BACK_HAND_UP_LINEAR = 163;
+    private static final int EFFECT_GESTURE_BACK_V2 = 0;
+    // Stock V2 plays effect 0 for both stages; enhanced mode uses a distinct hand-up.
+    private static final int EFFECT_GESTURE_BACK_HAND_UP_V2_ENHANCED = 1;
+    private static final long LINEAR_HAND_UP_BLOCK_MS = 140L;
+
+    interface Logger {
+        void log(int priority, String message, Throwable throwable);
+    }
+
+    private final Logger logger;
+    private final Executor executor = Executors.newSingleThreadExecutor();
+    private final Object hapticFeedbackUtil;
+    private final Method performExtHapticFeedback;
+    private final boolean supported;
+    private final boolean hapticV2;
+    private volatile boolean enhancedMode;
+    private volatile long lastReadyBackUptime;
+
+    MiuiHapticFeedbackHelper(Context context, Logger logger) {
+        this.logger = logger;
+        Object util = null;
+        Method perform = null;
+        boolean resolvedSupported = false;
+        boolean resolvedV2 = false;
+        try {
+            Class<?> utilClass = Class.forName("miui.util.HapticFeedbackUtil");
+            boolean linearMotor = Boolean.TRUE.equals(utilClass
+                    .getMethod("isSupportLinearMotorVibrate").invoke(null));
+            if (linearMotor) {
+                util = utilClass.getConstructor(Context.class, boolean.class)
+                        .newInstance(context, Boolean.TRUE);
+                Method support = utilClass.getMethod(
+                        "isSupportExtHapticFeedback", int.class);
+                perform = utilClass.getMethod("performExtHapticFeedback", int.class);
+                resolvedSupported = Boolean.TRUE.equals(support.invoke(util,
+                        Integer.valueOf(EFFECT_GESTURE_READY_BACK_LINEAR)))
+                        && Boolean.TRUE.equals(support.invoke(util,
+                        Integer.valueOf(EFFECT_GESTURE_BACK_HAND_UP_LINEAR)));
+            }
+            Class<?> systemProperties = Class.forName("android.os.SystemProperties");
+            Object version = systemProperties
+                    .getMethod("get", String.class, String.class)
+                    .invoke(null, "sys.haptic.version", "1.0");
+            resolvedV2 = "2.0".equals(version);
+        } catch (Throwable throwable) {
+            logger.log(Log.WARN, "MIUI haptic feedback unavailable"
+                    + ", policy=keepNativePanelHaptics", throwable);
+            util = null;
+            perform = null;
+            resolvedSupported = false;
+        }
+        this.hapticFeedbackUtil = util;
+        this.performExtHapticFeedback = perform;
+        this.supported = resolvedSupported && util != null && perform != null;
+        this.hapticV2 = resolvedV2;
+        if (this.supported) {
+            logger.log(Log.INFO, "MIUI two-stage back haptics ready"
+                    + ", hapticV2=" + resolvedV2, null);
+        }
+    }
+
+    boolean isSupported() {
+        return supported;
+    }
+
+    boolean isHapticV2() {
+        return hapticV2;
+    }
+
+    /**
+     * Enhanced release feedback: every committed release plays hand-up, V2 devices use
+     * effect 1 instead of 0, and the 140ms blocker also applies to V2. Disabled keeps
+     * the stock behavior.
+     */
+    void setEnhancedMode(boolean enabled) {
+        enhancedMode = enabled;
+    }
+
+    boolean isEnhancedMode() {
+        return enhancedMode;
+    }
+
+    /** Arrow fade-in completed; mirrors performGestureReadyBack(). */
+    void performReadyBack() {
+        if (!supported) {
+            return;
+        }
+        if (!hapticV2 || enhancedMode) {
+            lastReadyBackUptime = SystemClock.uptimeMillis();
+        }
+        play(hapticV2 ? EFFECT_GESTURE_BACK_V2 : EFFECT_GESTURE_READY_BACK_LINEAR);
+    }
+
+    /** Committed release; mirrors performGestureBackHandUp() with the 140ms blocker. */
+    void performHandUp() {
+        if (!supported) {
+            return;
+        }
+        if ((!hapticV2 || enhancedMode) && SystemClock.uptimeMillis() - lastReadyBackUptime
+                < LINEAR_HAND_UP_BLOCK_MS) {
+            return;
+        }
+        int effect;
+        if (hapticV2) {
+            effect = enhancedMode
+                    ? EFFECT_GESTURE_BACK_HAND_UP_V2_ENHANCED : EFFECT_GESTURE_BACK_V2;
+        } else {
+            effect = EFFECT_GESTURE_BACK_HAND_UP_LINEAR;
+        }
+        play(effect);
+    }
+
+    private void play(int effectId) {
+        executor.execute(() -> {
+            try {
+                performExtHapticFeedback.invoke(hapticFeedbackUtil,
+                        Integer.valueOf(effectId));
+            } catch (Throwable throwable) {
+                logger.log(Log.WARN, "Failed to play MIUI ext haptic effect "
+                        + effectId, throwable);
+            }
+        });
+    }
+}

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/MiuiStyleBackArrowOverlay.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/MiuiStyleBackArrowOverlay.java
@@ -1,0 +1,551 @@
+package dev.codex.miuibackgesturehook.hooks.systemui;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.ValueAnimator;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Matrix;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.Gravity;
+import android.view.View;
+import android.view.WindowManager;
+import android.view.animation.DecelerateInterpolator;
+import android.view.animation.Interpolator;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Visual-only port of MiuiHome's {@code GestureBackArrowView} water-drop back indicator,
+ * rendered inside SystemUI while the hidden native {@code BackPanelController} keeps
+ * owning gesture state, commit thresholds, and haptics.
+ *
+ * <p>The two bitmaps come from the live {@code com.miui.home} package resources so the
+ * appearance stays pixel-identical to the stock HyperOS indicator. All entry points must
+ * run on the main Looper except {@link #detach()}, which reposts itself.
+ */
+final class MiuiStyleBackArrowOverlay {
+
+    interface Logger {
+        void log(int priority, String message, Throwable throwable);
+    }
+
+    /**
+     * Fired when the arrow finishes its 100ms fade-in, matching Xiaomi's
+     * ready-back haptic timing in GestureBackArrowView.
+     */
+    interface HapticListener {
+        void onArrowReady();
+    }
+
+    static final int EDGE_LEFT = 0;
+    static final int EDGE_RIGHT = 1;
+
+    private static final String MIUI_HOME_PACKAGE = "com.miui.home";
+    private static final String RESOURCE_BACKGROUND = "gesture_back_background";
+    private static final String RESOURCE_ARROW = "gesture_back_arrow";
+    // Maximum laterFriction(x, 0.8, 2.0, 0.5) value is 0.8 + (2.0 / 3.0) * 0.5.
+    private static final float MAX_BACKGROUND_SCALE = 1.14f;
+    // WindowManager.LayoutParams.TYPE_NAVIGATION_BAR_PANEL (@hide),
+    // FIRST_SYSTEM_WINDOW + 24 — the same window type the native BackPanel uses.
+    private static final int TYPE_NAVIGATION_BAR_PANEL = 2024;
+
+    private final Context context;
+    private final Logger logger;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    private ArrowView view;
+    private WindowManager.LayoutParams layoutParams;
+    private int attachedEdge = -1;
+    private boolean windowAdded;
+
+    private Bitmap leftBackground;
+    private Bitmap rightBackground;
+    private Bitmap arrow;
+    private int loadedDensityDpi = -1;
+    private int loadedUiNightMode = -1;
+    private boolean resourceFailureLogged;
+    private HapticListener hapticListener;
+    private boolean hapticsEnabledForGesture;
+
+    MiuiStyleBackArrowOverlay(Context context, Logger logger) {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    void setHapticListener(HapticListener listener) {
+        hapticListener = listener;
+    }
+
+    /**
+     * Decided per gesture at ACTION_DOWN; off keeps this overlay fully silent.
+     */
+    void setHapticsForGesture(boolean enabled) {
+        hapticsEnabledForGesture = enabled;
+    }
+
+    /**
+     * Whether the ready-back haptic already played for the current arrow show.
+     */
+    boolean isArrowFeedbackDone() {
+        ArrowView current = view;
+        return current == null || current.arrowFeedbackDone;
+    }
+
+    /**
+     * Blocks a late fade-in completion from vibrating after the gesture ended.
+     */
+    void markArrowFeedbackDone() {
+        ArrowView current = view;
+        if (current != null) {
+            current.arrowFeedbackDone = true;
+        }
+    }
+
+    private void dispatchArrowReady() {
+        HapticListener listener = hapticListener;
+        if (hapticsEnabledForGesture && listener != null) {
+            listener.onArrowReady();
+        }
+    }
+
+    /**
+     * Loads MiuiHome resources and (re)attaches the overlay window for the given edge.
+     * Returns false when the HyperOS skin cannot be shown; callers must then leave the
+     * native AOSP panel visible.
+     */
+    boolean prepare(int edge) {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            return false;
+        }
+        if (!loadResources()) {
+            return false;
+        }
+        try {
+            ensureWindow(edge);
+            return view != null && windowAdded;
+        } catch (Throwable throwable) {
+            logger.log(Log.WARN, "Failed to attach HyperOS-style back indicator window",
+                    throwable);
+            return false;
+        }
+    }
+
+    void onGestureStart(float rawY, int edge) {
+        ArrowView current = view;
+        if (current == null) {
+            return;
+        }
+        int[] location = new int[2];
+        try {
+            current.getLocationOnScreen(location);
+        } catch (Throwable ignored) {
+            location[1] = 0;
+        }
+        current.onSwipeStart(rawY - location[1], edge == EDGE_LEFT
+                ? ArrowView.POSITION_LEFT : ArrowView.POSITION_RIGHT);
+    }
+
+    void onGestureProgress(float offsetPx, boolean arrowLit) {
+        ArrowView current = view;
+        if (current != null) {
+            current.onSwipeProgress(offsetPx, arrowLit);
+        }
+    }
+
+    /**
+     * Pass a negative offset to retract from the last drawn scale (cancellation).
+     */
+    void onGestureEnd(float offsetPx) {
+        ArrowView current = view;
+        if (current != null) {
+            current.onSwipeStop(offsetPx);
+        }
+    }
+
+    /**
+     * Safe from any thread; used by driver detach and hot reload teardown.
+     */
+    void detach() {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            mainHandler.post(this::detach);
+            return;
+        }
+        ArrowView current = view;
+        view = null;
+        layoutParams = null;
+        attachedEdge = -1;
+        boolean added = windowAdded;
+        windowAdded = false;
+        if (current != null) {
+            current.cancelAnimations();
+            if (added) {
+                try {
+                    WindowManager windowManager =
+                            context.getSystemService(WindowManager.class);
+                    windowManager.removeViewImmediate(current);
+                } catch (Throwable throwable) {
+                    logger.log(Log.WARN,
+                            "Failed to remove HyperOS-style back indicator window",
+                            throwable);
+                }
+            }
+        }
+    }
+
+    private void ensureWindow(int edge) {
+        if (view != null && windowAdded && attachedEdge == edge) {
+            return;
+        }
+        WindowManager windowManager = context.getSystemService(WindowManager.class);
+        if (view == null || !windowAdded) {
+            detachDanglingView(windowManager);
+            ArrowView created = new ArrowView(context, this);
+            WindowManager.LayoutParams params = buildLayoutParams(edge);
+            windowManager.addView(created, params);
+            view = created;
+            layoutParams = params;
+            windowAdded = true;
+            attachedEdge = edge;
+            logger.log(Log.INFO, "Attached HyperOS-style back indicator window"
+                    + ", edge=" + edge
+                    + ", width=" + params.width, null);
+            return;
+        }
+        layoutParams.gravity = gravityForEdge(edge);
+        windowManager.updateViewLayout(view, layoutParams);
+        attachedEdge = edge;
+    }
+
+    private void detachDanglingView(WindowManager windowManager) {
+        ArrowView dangling = view;
+        view = null;
+        if (dangling != null && windowAdded) {
+            windowAdded = false;
+            try {
+                windowManager.removeViewImmediate(dangling);
+            } catch (Throwable ignored) {
+            }
+        }
+    }
+
+    private WindowManager.LayoutParams buildLayoutParams(int edge) {
+        int width = Math.max(1, Math.round(
+                leftBackground.getWidth() * MAX_BACKGROUND_SCALE) + 1);
+        WindowManager.LayoutParams params = new WindowManager.LayoutParams(
+                width,
+                WindowManager.LayoutParams.MATCH_PARENT,
+                TYPE_NAVIGATION_BAR_PANEL,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                        | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                        | WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN
+                        | WindowManager.LayoutParams.FLAG_SPLIT_TOUCH,
+                PixelFormat.TRANSLUCENT);
+        params.setTitle("MiuiBackGestureHookIndicator");
+        params.gravity = gravityForEdge(edge);
+        params.setFitInsetsTypes(0);
+        params.layoutInDisplayCutoutMode =
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
+        return params;
+    }
+
+    @SuppressLint("RtlHardcoded")
+    private static int gravityForEdge(int edge) {
+        return Gravity.TOP | (edge == EDGE_LEFT ? Gravity.LEFT : Gravity.RIGHT);
+    }
+
+    @SuppressLint("DiscouragedApi")
+    private boolean loadResources() {
+        Configuration configuration = context.getResources().getConfiguration();
+        int densityDpi = configuration.densityDpi;
+        int uiNightMode = configuration.uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        if (leftBackground != null && arrow != null
+                && densityDpi == loadedDensityDpi && uiNightMode == loadedUiNightMode) {
+            return true;
+        }
+        try {
+            Context homeContext = context.createPackageContext(MIUI_HOME_PACKAGE,
+                    Context.CONTEXT_IGNORE_SECURITY);
+            Resources homeResources = homeContext.getResources();
+            int backgroundId = homeResources.getIdentifier(
+                    RESOURCE_BACKGROUND, "drawable", MIUI_HOME_PACKAGE);
+            int arrowId = homeResources.getIdentifier(
+                    RESOURCE_ARROW, "drawable", MIUI_HOME_PACKAGE);
+            if (backgroundId == 0 || arrowId == 0) {
+                throw new Resources.NotFoundException(
+                        "backgroundId=" + backgroundId + ", arrowId=" + arrowId);
+            }
+            Bitmap loadedBackground =
+                    BitmapFactory.decodeResource(homeResources, backgroundId);
+            Bitmap loadedArrow = BitmapFactory.decodeResource(homeResources, arrowId);
+            if (loadedBackground == null || loadedArrow == null) {
+                throw new IllegalStateException("decoded background="
+                        + loadedBackground + ", arrow=" + loadedArrow);
+            }
+            Matrix rotate = new Matrix();
+            rotate.postRotate(180.0f);
+            leftBackground = loadedBackground;
+            rightBackground = Bitmap.createBitmap(loadedBackground, 0, 0,
+                    loadedBackground.getWidth(), loadedBackground.getHeight(),
+                    rotate, true);
+            arrow = loadedArrow;
+            loadedDensityDpi = densityDpi;
+            loadedUiNightMode = uiNightMode;
+            resourceFailureLogged = false;
+            logger.log(Log.INFO, "Loaded HyperOS back indicator resources from MiuiHome"
+                    + ", background=" + loadedBackground.getWidth()
+                    + "x" + loadedBackground.getHeight()
+                    + ", arrow=" + loadedArrow.getWidth()
+                    + "x" + loadedArrow.getHeight()
+                    + ", densityDpi=" + densityDpi, null);
+            return true;
+        } catch (Throwable throwable) {
+            if (!resourceFailureLogged) {
+                resourceFailureLogged = true;
+                logger.log(Log.WARN, "HyperOS back indicator resources unavailable"
+                        + ", policy=keepNativeAospPanel", throwable);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Drawing port of {@code com.miui.home.recents.GestureBackArrowView}. The background
+     * water-drop scales with {@code laterFriction} damping and the arrow fades in/out with
+     * the original 100ms/50ms cubic-ease animations. Haptics stay with the hidden native
+     * BackPanelController, so this view never vibrates.
+     */
+    private static final class ArrowView extends View {
+        static final int POSITION_LEFT = 0;
+        static final int POSITION_RIGHT = 1;
+
+        private static final Interpolator CUBIC_EASE_OUT_INTERPOLATOR =
+                new DecelerateInterpolator(1.5f);
+        private static final Interpolator QUAD_EASE_OUT_INTERPOLATOR =
+                new DecelerateInterpolator();
+
+        private final MiuiStyleBackArrowOverlay overlay;
+        private final Paint backgroundPaint;
+        private final Paint arrowPaint;
+        private final Rect backgroundDstRect = new Rect();
+        private final Rect arrowDstRect = new Rect();
+
+        private ValueAnimator arrowAnimator;
+        private ValueAnimator finishAnimator;
+        private int position = POSITION_LEFT;
+        private float backgroundScale;
+        private float startY;
+        private float expectBackHeight;
+        private boolean arrowLit;
+        private boolean arrowShown;
+        private boolean iconNeedDraw;
+        private int currentArrowAlpha;
+        boolean arrowFeedbackDone;
+
+        ArrowView(Context context, MiuiStyleBackArrowOverlay overlay) {
+            super(context);
+            this.overlay = overlay;
+            backgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            backgroundPaint.setFilterBitmap(true);
+            backgroundPaint.setDither(true);
+            arrowPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            arrowPaint.setFilterBitmap(true);
+            arrowPaint.setDither(true);
+            arrowPaint.setAlpha(0);
+        }
+
+        // Mirrors BackGestureUtils.convertOffset(): linear for the first 80% of
+        // offset/360 and cubic-polynomial friction beyond it, returning the 0..~1.13
+        // background scale directly (Xiaomi divides its 0..20 result by 20).
+        static float convertOffsetToScale(float offset) {
+            if (offset < 0.0f) {
+                return 0.0f;
+            }
+            return laterFriction(offset / 360.0f);
+        }
+
+        private static float laterFriction(float value) {
+            if (value < (float) 0.8) {
+                return value;
+            }
+            return (float) 0.8
+                    + afterFrictionValue(value - (float) 0.8)
+                    * (float) 0.5;
+        }
+
+        private static float afterFrictionValue(float value) {
+            int sign = value >= 0.0f ? 1 : -1;
+            float normalized = (float) Math.min(Math.abs(value) / (float) 2.0, 1.0d);
+            float squared = normalized * normalized;
+            return sign * ((squared * normalized / 3) - squared + normalized) * (float) 2.0;
+        }
+
+        void onSwipeStart(float localY, int newPosition) {
+            cancelFinishAnimation();
+            position = newPosition;
+            Bitmap background = currentBackground();
+            expectBackHeight = background == null ? 0.0f : background.getHeight();
+            // Matches Xiaomi's no-explicit-height branch in setStartLocation().
+            startY = localY - 20.0f;
+            arrowPaint.setAlpha(0);
+            currentArrowAlpha = 0;
+            arrowShown = false;
+            iconNeedDraw = false;
+            arrowLit = false;
+            backgroundScale = 0.0f;
+            invalidate();
+        }
+
+        void onSwipeProgress(float offset, boolean lit) {
+            arrowLit = lit;
+            backgroundScale = convertOffsetToScale(offset);
+            invalidate();
+        }
+
+        void onSwipeStop(float releaseOffset) {
+            arrowLit = false;
+            if (arrowAnimator != null) {
+                arrowAnimator.cancel();
+            }
+            float startScale = releaseOffset >= 0.0f
+                    ? convertOffsetToScale(releaseOffset) : backgroundScale;
+            backgroundScale = startScale;
+            ValueAnimator animator = ValueAnimator.ofFloat(startScale, 0.0f);
+            animator.setDuration(100L);
+            animator.setInterpolator(QUAD_EASE_OUT_INTERPOLATOR);
+            animator.addUpdateListener(animation -> {
+                backgroundScale = (Float) animation.getAnimatedValue();
+                long playTime = animation.getCurrentPlayTime();
+                if (playTime > 0 && playTime < 50) {
+                    iconNeedDraw = false;
+                    arrowShown = false;
+                }
+                invalidate();
+            });
+            finishAnimator = animator;
+            animator.start();
+        }
+
+        void cancelAnimations() {
+            if (arrowAnimator != null) {
+                arrowAnimator.cancel();
+            }
+            cancelFinishAnimation();
+        }
+
+        private void cancelFinishAnimation() {
+            if (finishAnimator != null) {
+                finishAnimator.end();
+                finishAnimator = null;
+            }
+        }
+
+        private Bitmap currentBackground() {
+            return position == POSITION_LEFT
+                    ? overlay.leftBackground : overlay.rightBackground;
+        }
+
+        @Override
+        protected void onDraw(@NonNull Canvas canvas) {
+            super.onDraw(canvas);
+            Bitmap background = currentBackground();
+            Bitmap arrowBitmap = overlay.arrow;
+            if (background == null || arrowBitmap == null) {
+                return;
+            }
+            float scaledWidth = background.getWidth() * backgroundScale;
+            int arrowWidth = arrowBitmap.getWidth();
+            int backgroundLeft;
+            int backgroundRight;
+            int arrowLeft;
+            int arrowRight;
+            if (position == POSITION_LEFT) {
+                backgroundLeft = 0;
+                backgroundRight = (int) scaledWidth;
+                arrowLeft = (int) ((scaledWidth - arrowWidth) / 2.0f);
+                arrowRight = (int) ((scaledWidth + arrowWidth) / 2.0f);
+            } else {
+                int width = getWidth();
+                backgroundLeft = width - (int) scaledWidth;
+                backgroundRight = width;
+                arrowLeft = width - (int) ((scaledWidth + arrowWidth) / 2.0f);
+                arrowRight = width - (int) ((scaledWidth - arrowWidth) / 2.0f);
+            }
+            backgroundDstRect.set(backgroundLeft,
+                    (int) (startY - (expectBackHeight / 2.0f)),
+                    backgroundRight,
+                    (int) (startY + (expectBackHeight / 2.0f)));
+            canvas.drawBitmap(background, null, backgroundDstRect, backgroundPaint);
+            if (arrowLit) {
+                if (!arrowShown) {
+                    iconNeedDraw = true;
+                    startArrowAnimating(true, 100);
+                    arrowShown = true;
+                }
+            } else if (arrowShown) {
+                startArrowAnimating(false, 50);
+                arrowShown = false;
+            }
+            if (iconNeedDraw && backgroundScale > 0.1d && arrowLit) {
+                int arrowHeight = arrowBitmap.getHeight();
+                arrowDstRect.set(arrowLeft,
+                        (int) (startY - (arrowHeight / 2.0f)),
+                        arrowRight,
+                        (int) (startY + (arrowHeight / 2.0f)));
+                canvas.drawBitmap(arrowBitmap, null, arrowDstRect, arrowPaint);
+            }
+        }
+
+        private void startArrowAnimating(boolean show, int duration) {
+            if (arrowAnimator != null) {
+                arrowAnimator.cancel();
+            }
+            arrowFeedbackDone = false;
+            ValueAnimator animator = ValueAnimator.ofInt(
+                    currentArrowAlpha, show ? 255 : 0);
+            animator.setDuration(duration);
+            animator.setInterpolator(CUBIC_EASE_OUT_INTERPOLATOR);
+            animator.addUpdateListener(animation -> {
+                int alpha = (Integer) animation.getAnimatedValue();
+                arrowPaint.setAlpha(alpha);
+                invalidate();
+                if (alpha == 0 && !show) {
+                    iconNeedDraw = false;
+                }
+                currentArrowAlpha = alpha;
+            });
+            if (show) {
+                // Xiaomi's AnimationSuccessListener: the ready-back haptic fires only
+                // when the fade-in completes uncancelled and has not fired yet.
+                animator.addListener(new AnimatorListenerAdapter() {
+                    private boolean cancelled;
+
+                    @Override
+                    public void onAnimationCancel(Animator animation) {
+                        cancelled = true;
+                    }
+
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        if (!cancelled && !arrowFeedbackDone) {
+                            arrowFeedbackDone = true;
+                            overlay.dispatchArrowReady();
+                        }
+                    }
+                });
+            }
+            arrowAnimator = animator;
+            animator.start();
+        }
+    }
+}

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
@@ -2,86 +2,44 @@ package dev.codex.miuibackgesturehook.hooks.systemui;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
-import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
-import android.app.ActivityManager;
-import android.app.BroadcastOptions;
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.SharedPreferences;
-import android.content.pm.ActivityInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
-import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.RectF;
-import android.graphics.Region;
-import android.hardware.input.InputManager;
-import android.os.Binder;
-import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
-import android.os.IInterface;
 import android.os.Looper;
 import android.os.Parcel;
-import android.os.Parcelable;
 import android.os.Process;
 import android.os.SystemClock;
-import android.provider.Settings;
 import android.util.Log;
-import android.util.Pair;
-import android.util.SparseArray;
-import android.view.Choreographer;
-import android.view.InputChannel;
-import android.view.InputEvent;
-import android.view.InputEventReceiver;
-import android.view.InputMonitor;
-import android.view.MotionEvent;
 import android.view.SurfaceControl;
 import android.view.View;
-import android.view.WindowInsets;
-import android.view.WindowManager;
-import android.view.animation.DecelerateInterpolator;
-import android.view.animation.PathInterpolator;
+import android.window.BackEvent;
 import android.window.BackMotionEvent;
 import android.window.BackNavigationInfo;
 import android.window.BackProgressAnimator;
 import android.window.BackTouchTracker;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import io.github.libxposed.api.XposedInterface;
-import io.github.libxposed.api.XposedModule;
-import io.github.libxposed.api.XposedModuleInterface;
 
 public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
 
@@ -303,7 +261,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
     }
 
     protected void invalidateOpenTransitionSnapshot(OpenTransitionSnapshot snapshot,
-                                                  String reason) {
+                                                    String reason) {
         if (snapshot == null) {
             return;
         }
@@ -1028,9 +986,9 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
     }
 
     protected void attachHeadlessNavBarLease(Object controller, Object navBarHelper,
-                                           Object edgeBackGestureHandler,
-                                           Object backAnimation, int navigationMode,
-                                           String reason) throws Exception {
+                                             Object edgeBackGestureHandler,
+                                             Object backAnimation, int navigationMode,
+                                             String reason) throws Exception {
         ClassLoader classLoader = controller.getClass().getClassLoader();
         Class<?> updaterInterface = Class.forName(
                 NAV_BAR_STATE_UPDATER, false, classLoader);
@@ -1447,10 +1405,517 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
             hookBackPrepareTransitionReparent(classLoader);
             hookBackCommitComposition(classLoader);
             hookBackFinishOpenAtomicTransfer(classLoader);
+            hookCrossActivitySlideAnimation(classLoader,
+                    true, true, true, true, true);
             log(Log.INFO, TAG, "Hooked Shell BackAnimationController AOSP path");
         } catch (Throwable throwable) {
             log(Log.ERROR, TAG, "Failed to hook Shell back animation", throwable);
         }
+    }
+
+    /**
+     * Restyles the native cross-activity (and, via the unified registry entry,
+     * cross-task) predictive-back animation into the miuix slide when the preference is
+     * on: the closing surface follows the finger full-width with no scale and no fade,
+     * the entering surface parallaxes in from a quarter width behind at alpha 0.9 -> 1
+     * with its dim scrim tracking the drag and its corner radius cleared, and the commit
+     * settles on a cubic ease-out. Only the geometry, scrim, and entering corner radius
+     * are replaced; targets, letterboxes, and the finish lifecycle stay native.
+     * Return-to-home is untouched.
+     */
+    protected void hookCrossActivitySlideAnimation(ClassLoader classLoader,
+                                                   boolean installStart,
+                                                   boolean installProgress,
+                                                   boolean installPostCommit,
+                                                   boolean installDuration,
+                                                   boolean installFinish) {
+        Class<?> baseClass;
+        Class<?> defaultClass;
+        Class<?> backMotionEventClass;
+        Class<?> backEventClass;
+        try {
+            baseClass = Class.forName(
+                    CROSS_ACTIVITY_BACK_ANIMATION, false, classLoader);
+            defaultClass = Class.forName(
+                    DEFAULT_CROSS_ACTIVITY_BACK_ANIMATION, false, classLoader);
+            backMotionEventClass = Class.forName(
+                    "android.window.BackMotionEvent", false, classLoader);
+            backEventClass = Class.forName(
+                    "android.window.BackEvent", false, classLoader);
+        } catch (Throwable throwable) {
+            log(Log.ERROR, TAG, "Cross-activity animation classes unavailable",
+                    throwable);
+            return;
+        }
+        // Each hook installs independently: R8 may rename individual members in
+        // Xiaomi's build, and a missing one must only degrade its own stage.
+        if (installStart) {
+            try {
+                Method start = resolveSlideMethod(defaultClass, baseClass,
+                        "startBackAnimation", void.class, backMotionEventClass);
+                recordHookHandle(hook(start)
+                        .setId("systemui_back_slide_start")
+                        .intercept(this::onCrossActivitySlideStart));
+                log(Log.INFO, TAG, "Hooked slide start as " + start.getName());
+            } catch (Throwable throwable) {
+                log(Log.ERROR, TAG, "Failed to hook slide start", throwable);
+            }
+        }
+        if (installProgress) {
+            try {
+                // R8 inlines the private per-frame method into its registration
+                // lambda, so the stable interception point is the framework
+                // BackProgressAnimator: swap the registered ProgressCallback for the
+                // armed animation's own animator and drive the frames ourselves.
+                Method register = BackProgressAnimator.class.getDeclaredMethod(
+                        "onBackStarted", BackMotionEvent.class,
+                        BackProgressAnimator.ProgressCallback.class);
+                register.setAccessible(true);
+                recordHookHandle(hook(register)
+                        .setId("systemui_back_slide_progress")
+                        .intercept(this::onCrossActivitySlideProgressRegistration));
+                log(Log.INFO, TAG,
+                        "Hooked slide progress via BackProgressAnimator registration");
+            } catch (Throwable throwable) {
+                log(Log.ERROR, TAG, "Failed to hook slide progress", throwable);
+            }
+        }
+        if (installPostCommit) {
+            try {
+                Method postCommit = resolveSlideMethod(defaultClass, baseClass,
+                        "onPostCommitProgress", void.class, float.class);
+                // Hooked on the base class means this is the super-call position:
+                // the subclass override keeps writing its native geometry after our
+                // interceptor returns, so our frame must be applied afterwards.
+                miuixSlidePostCommitOnBase =
+                        postCommit.getDeclaringClass() == baseClass;
+                recordHookHandle(hook(postCommit)
+                        .setId("systemui_back_slide_post_commit")
+                        .intercept(this::onCrossActivitySlidePostCommit));
+                log(Log.INFO, TAG, "Hooked slide post-commit as "
+                        + postCommit.getDeclaringClass().getSimpleName()
+                        + "." + postCommit.getName()
+                        + ", superPosition=" + miuixSlidePostCommitOnBase);
+            } catch (Throwable throwable) {
+                log(Log.ERROR, TAG, "Failed to hook slide post-commit", throwable);
+            }
+        }
+        if (installDuration) {
+            try {
+                Method duration = resolveSlideMethod(defaultClass, baseClass,
+                        "getPostCommitAnimationDuration", long.class);
+                recordHookHandle(hook(duration)
+                        .setId("systemui_back_slide_duration")
+                        .intercept(this::onCrossActivitySlideDuration));
+                log(Log.INFO, TAG, "Hooked slide duration as " + duration.getName());
+            } catch (Throwable throwable) {
+                log(Log.ERROR, TAG, "Failed to hook slide duration", throwable);
+            }
+        }
+        if (installFinish) {
+            try {
+                Method finish = resolveSlideMethod(defaultClass, baseClass,
+                        "finishAnimation", void.class);
+                recordHookHandle(hook(finish)
+                        .setId("systemui_back_slide_finish")
+                        .intercept(this::onCrossActivitySlideFinish));
+                log(Log.INFO, TAG, "Hooked slide finish as "
+                        + finish.getDeclaringClass().getSimpleName()
+                        + "." + finish.getName());
+            } catch (Throwable throwable) {
+                log(Log.ERROR, TAG, "Failed to hook slide finish", throwable);
+            }
+        }
+    }
+
+    // finishAnimation() is the animation's natural end; clear the session flag so a
+    // later gesture re-arms cleanly. The original always runs.
+    protected Object onCrossActivitySlideFinish(XposedInterface.Chain chain)
+            throws Throwable {
+        miuixSlideAnimActive = false;
+        return chain.proceed();
+    }
+
+    /**
+     * Resolves an animation-class member by name first, then falls back to a unique
+     * signature match so an R8-renamed member is still found. Same-name declarations
+     * across the hierarchy are one virtual method — the most-derived one wins;
+     * different-name candidates at the same level are ambiguous and fail.
+     */
+    protected Method resolveSlideMethod(Class<?> leaf, Class<?> stop, String name,
+                                        Class<?> returnType, Class<?>... parameters)
+            throws NoSuchMethodException {
+        try {
+            return findDeclaredMethodInHierarchy(leaf, stop, name, parameters);
+        } catch (NoSuchMethodException ignored) {
+        }
+        Class<?> current = leaf;
+        while (current != null) {
+            Method match = null;
+            for (Method candidate : current.getDeclaredMethods()) {
+                if (candidate.isSynthetic()
+                        || candidate.getReturnType() != returnType
+                        || !Arrays.equals(candidate.getParameterTypes(), parameters)) {
+                    continue;
+                }
+                if (match != null) {
+                    throw new NoSuchMethodException(name
+                            + ": ambiguous signature fallback in " + current.getName()
+                            + " (" + match.getName() + " vs " + candidate.getName()
+                            + ")");
+                }
+                match = candidate;
+            }
+            if (match != null) {
+                match.setAccessible(true);
+                log(Log.INFO, TAG, "Resolved " + name + " by signature as "
+                        + current.getName() + "." + match.getName());
+                return match;
+            }
+            if (current == stop) {
+                break;
+            }
+            current = current.getSuperclass();
+        }
+        throw new NoSuchMethodException(leaf.getName() + "." + name);
+    }
+
+    protected Method findDeclaredMethodInHierarchy(Class<?> leaf, Class<?> stop,
+                                                   String name, Class<?>... parameters)
+            throws NoSuchMethodException {
+        Class<?> current = leaf;
+        while (current != null) {
+            try {
+                Method method = current.getDeclaredMethod(name, parameters);
+                method.setAccessible(true);
+                return method;
+            } catch (NoSuchMethodException ignored) {
+            }
+            if (current == stop) {
+                break;
+            }
+            current = current.getSuperclass();
+        }
+        throw new NoSuchMethodException(leaf.getName() + "." + name);
+    }
+
+    protected volatile boolean miuixSlideAnimActive;
+    protected final RectF miuixSlideCommitClosing = new RectF();
+    protected final RectF miuixSlideCommitEntering = new RectF();
+    protected boolean miuixSlideCommitPoseCaptured;
+    protected float miuixSlideCommitEnteringAlpha = 1.0f;
+    protected float miuixSlideCommitScrimRemaining = 1.0f;
+    protected boolean miuixSlidePostCommitOnBase;
+    protected volatile WeakReference<Object> miuixSlideArmedAnimation;
+    protected boolean miuixSlideRegistrationReentry;
+    protected volatile Method crossActivityApplyTransform;
+    protected volatile Object crossActivityNoFling;
+
+    protected static final long MIUIX_SLIDE_SETTLE_DURATION_MS = 400L;
+    protected static final float MIUIX_SLIDE_ENTERING_MIN_ALPHA = 0.9f;
+    protected static final float MIUIX_SLIDE_PARALLAX_FRACTION = 0.25f;
+
+    protected Object onCrossActivitySlideStart(XposedInterface.Chain chain)
+            throws Throwable {
+        Object result = chain.proceed();
+        try {
+            Object animation = chain.getThisObject();
+            miuixSlideCommitPoseCaptured = false;
+            if (!isHyperOsSlideAnimationEnabled()) {
+                miuixSlideAnimActive = false;
+                return result;
+            }
+            if (readField(animation, "closingTarget") == null
+                    || readField(animation, "enteringTarget") == null) {
+                miuixSlideAnimActive = false;
+                return result;
+            }
+            Rect backAnimRect = (Rect) readField(animation, "backAnimRect");
+            float width = backAnimRect.width();
+            if (width <= 0f) {
+                miuixSlideAnimActive = false;
+                return result;
+            }
+            Context animationContext = (Context) readField(animation, "context");
+            boolean rtl = animationContext.getResources().getConfiguration()
+                    .getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+            float slide = rtl ? -width : width;
+            RectF startClosing = (RectF) readField(animation, "startClosingRect");
+            RectF targetClosing = (RectF) readField(animation, "targetClosingRect");
+            RectF startEntering = (RectF) readField(animation, "startEnteringRect");
+            RectF targetEntering = (RectF) readField(animation, "targetEnteringRect");
+            startClosing.set(backAnimRect);
+            targetClosing.set(backAnimRect);
+            targetClosing.offset(slide, 0f);
+            targetEntering.set(backAnimRect);
+            startEntering.set(backAnimRect);
+            startEntering.offset(-slide * MIUIX_SLIDE_PARALLAX_FRACTION, 0f);
+            miuixSlideArmedAnimation = new WeakReference<>(animation);
+            miuixSlideAnimActive = true;
+            log(Log.INFO, TAG, "Armed miuix slide back animation"
+                    + ", width=" + width + ", rtl=" + rtl);
+        } catch (Throwable throwable) {
+            miuixSlideAnimActive = false;
+            log(Log.WARN, TAG, "Failed to arm miuix slide geometry", throwable);
+        }
+        return result;
+    }
+
+    /**
+     * Fires when any BackProgressAnimator registers its per-gesture ProgressCallback.
+     * For the armed cross-activity animation's own animator, the native callback (the
+     * inlined geometry) is replaced with the miuix frame driver; every other animator
+     * registers untouched.
+     */
+    protected Object onCrossActivitySlideProgressRegistration(
+            XposedInterface.Chain chain) throws Throwable {
+        if (miuixSlideRegistrationReentry || !miuixSlideAnimActive) {
+            return chain.proceed();
+        }
+        WeakReference<Object> armedReference = miuixSlideArmedAnimation;
+        Object animation = armedReference == null ? null : armedReference.get();
+        if (animation == null) {
+            return chain.proceed();
+        }
+        Object progressAnimator;
+        try {
+            progressAnimator = readField(animation, "progressAnimator");
+        } catch (Throwable throwable) {
+            log(Log.WARN, TAG, "Failed to read progressAnimator", throwable);
+            return chain.proceed();
+        }
+        if (progressAnimator != chain.getThisObject()) {
+            return chain.proceed();
+        }
+        Object originalCallback = chain.getArg(1);
+        BackProgressAnimator.ProgressCallback replacement = event -> {
+            try {
+                onMiuixSlideFrame(animation, event);
+            } catch (Throwable throwable) {
+                miuixSlideAnimActive = false;
+                log(Log.WARN, TAG, "miuix slide frame failed"
+                        + ", fallingBackToNativeCallback=true", throwable);
+                if (originalCallback instanceof BackProgressAnimator.ProgressCallback) {
+                    ((BackProgressAnimator.ProgressCallback) originalCallback)
+                            .onProgressUpdate(event);
+                }
+            }
+        };
+        miuixSlideRegistrationReentry = true;
+        try {
+            ((BackProgressAnimator) chain.getThisObject()).onBackStarted(
+                    (BackMotionEvent) chain.getArg(0), replacement);
+        } finally {
+            miuixSlideRegistrationReentry = false;
+        }
+        log(Log.INFO, TAG, "miuix slide progress callback proxied");
+        return null;
+    }
+
+    protected void onMiuixSlideFrame(Object animation, BackEvent backEvent)
+            throws Exception {
+        if (!miuixSlideAnimActive) {
+            return;
+        }
+        // The delivered progress already tracks the finger through
+        // BackProgressAnimator's smoothing spring (cancel rides it back to zero); mapping
+        // it linearly, without the native gesture interpolator, is the miuix slide.
+        float progress = Math.max(0.0f, Math.min(1.0f, backEvent.getProgress()));
+        writeField(animation, "gestureProgress", Float.valueOf(progress));
+        applyMiuixSlideFrame(animation, progress,
+                MIUIX_SLIDE_ENTERING_MIN_ALPHA
+                        + (1.0f - MIUIX_SLIDE_ENTERING_MIN_ALPHA) * progress);
+    }
+
+    protected Object onCrossActivitySlidePostCommit(XposedInterface.Chain chain)
+            throws Throwable {
+        if (!miuixSlideAnimActive) {
+            return chain.proceed();
+        }
+        try {
+            Object animation = chain.getThisObject();
+            float linear = ((Number) chain.getArg(0)).floatValue();
+            if (!miuixSlideCommitPoseCaptured) {
+                miuixSlideCommitClosing.set((RectF) readField(
+                        animation, "currentClosingRect"));
+                miuixSlideCommitEntering.set((RectF) readField(
+                        animation, "currentEnteringRect"));
+                float commitProgress = readFloatFieldOrDefault(
+                        animation, "gestureProgress", 0.0f);
+                miuixSlideCommitEnteringAlpha = MIUIX_SLIDE_ENTERING_MIN_ALPHA
+                        + (1.0f - MIUIX_SLIDE_ENTERING_MIN_ALPHA) * commitProgress;
+                // Continue the scrim fade from wherever the drag left it, not from full.
+                miuixSlideCommitScrimRemaining = 1.0f - commitProgress;
+                // The subclass onGestureCommitted (not hooked) rewrites the target
+                // rects to its own 0.9 card pose, so the slide would settle short of
+                // the edge. Restore the full slide-out destination for the settle.
+                Rect backAnimRect = (Rect) readField(animation, "backAnimRect");
+                Context animationContext = (Context) readField(animation, "context");
+                boolean rtl = animationContext.getResources().getConfiguration()
+                        .getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+                float slide = rtl ? -backAnimRect.width() : backAnimRect.width();
+                RectF targetClosing = (RectF) readField(
+                        animation, "targetClosingRect");
+                RectF targetEntering = (RectF) readField(
+                        animation, "targetEnteringRect");
+                targetClosing.set(backAnimRect);
+                targetClosing.offset(slide, 0f);
+                targetEntering.set(backAnimRect);
+                miuixSlideCommitPoseCaptured = true;
+            }
+            if (miuixSlidePostCommitOnBase) {
+                // Super-call position: the subclass override writes its native
+                // geometry after this hook returns. Reapply ours behind it on the
+                // same looper turn so the miuix frame is what reaches the compositor.
+                Handler frameHandler = new Handler(Objects.requireNonNull(Looper.myLooper()));
+                frameHandler.post(() -> {
+                    try {
+                        if (miuixSlideAnimActive) {
+                            applyMiuixSlidePostCommitFrame(animation, linear);
+                        }
+                    } catch (Throwable throwable) {
+                        miuixSlideAnimActive = false;
+                        log(Log.WARN, TAG, "miuix slide deferred post-commit failed",
+                                throwable);
+                    }
+                });
+                return null;
+            }
+            applyMiuixSlidePostCommitFrame(animation, linear);
+            return null;
+        } catch (Throwable throwable) {
+            miuixSlideAnimActive = false;
+            log(Log.WARN, TAG, "miuix slide post-commit frame failed", throwable);
+            return chain.proceed();
+        }
+    }
+
+    protected Object onCrossActivitySlideDuration(XposedInterface.Chain chain)
+            throws Throwable {
+        if (miuixSlideAnimActive) {
+            return Long.valueOf(MIUIX_SLIDE_SETTLE_DURATION_MS);
+        }
+        return chain.proceed();
+    }
+
+    protected void applyMiuixSlidePostCommitFrame(Object animation, float linear)
+            throws Exception {
+        float eased = miuixSlideSettleEase(linear);
+        RectF targetClosing = (RectF) readField(animation, "targetClosingRect");
+        RectF targetEntering = (RectF) readField(animation, "targetEnteringRect");
+        RectF currentClosing = (RectF) readField(animation, "currentClosingRect");
+        RectF currentEntering = (RectF) readField(animation, "currentEnteringRect");
+        lerpRectF(miuixSlideCommitClosing, targetClosing, eased, currentClosing);
+        lerpRectF(miuixSlideCommitEntering, targetEntering, eased, currentEntering);
+        float enteringAlpha = miuixSlideCommitEnteringAlpha
+                + (1.0f - miuixSlideCommitEnteringAlpha) * eased;
+        applyMiuixSlideScrim(animation,
+                miuixSlideCommitScrimRemaining * (1.0f - linear));
+        applyMiuixSlideTransforms(animation, currentClosing, currentEntering,
+                enteringAlpha);
+    }
+
+    // Dims the revealed layer proportionally to how much of the top page still covers
+    // it: remainingDim 1 = fully dimmed (top at rest), 0 = top gone. Follows the finger
+    // during the drag instead of snapping only at release.
+    protected void applyMiuixSlideScrim(Object animation, float remainingDim)
+            throws Exception {
+        Object scrim = readField(animation, "scrimLayer");
+        if (scrim instanceof SurfaceControl && ((SurfaceControl) scrim).isValid()) {
+            float maxScrimAlpha = readFloatFieldOrDefault(
+                    animation, "maxScrimAlpha", 0.0f);
+            ((SurfaceControl.Transaction) readField(animation, "transaction"))
+                    .setAlpha((SurfaceControl) scrim,
+                            maxScrimAlpha * Math.max(0.0f, Math.min(1.0f, remainingDim)));
+        }
+    }
+
+    protected void applyMiuixSlideFrame(Object animation, float progress,
+                                        float enteringAlpha) throws Exception {
+        RectF startClosing = (RectF) readField(animation, "startClosingRect");
+        RectF targetClosing = (RectF) readField(animation, "targetClosingRect");
+        RectF startEntering = (RectF) readField(animation, "startEnteringRect");
+        RectF targetEntering = (RectF) readField(animation, "targetEnteringRect");
+        RectF currentClosing = (RectF) readField(animation, "currentClosingRect");
+        RectF currentEntering = (RectF) readField(animation, "currentEnteringRect");
+        lerpRectF(startClosing, targetClosing, progress, currentClosing);
+        lerpRectF(startEntering, targetEntering, progress, currentEntering);
+        applyMiuixSlideScrim(animation, 1.0f - progress);
+        applyMiuixSlideTransforms(animation, currentClosing, currentEntering,
+                enteringAlpha);
+    }
+
+    protected void applyMiuixSlideTransforms(Object animation, RectF closingRect,
+                                             RectF enteringRect, float enteringAlpha)
+            throws Exception {
+        Object closingLeash = readFieldOrNull(
+                readField(animation, "closingTarget"), "leash");
+        Object enteringLeash = readFieldOrNull(
+                readField(animation, "enteringTarget"), "leash");
+        applyCrossActivityTransform(animation, closingLeash, closingRect, 1.0f);
+        applyCrossActivityTransform(animation, enteringLeash, enteringRect,
+                enteringAlpha);
+        // The revealed lower stack is full-screen behind the sliding top page; only the
+        // top card is rounded. Native applyTransform rounds both, so clear the corner
+        // radius the native call just set on the entering leash.
+        if (enteringLeash instanceof SurfaceControl
+                && ((SurfaceControl) enteringLeash).isValid()) {
+            Object transaction = readField(animation, "transaction");
+            invokeMethod(transaction, "setCornerRadius",
+                    new Class<?>[]{SurfaceControl.class, float.class},
+                    new Object[]{enteringLeash, Float.valueOf(0.0f)});
+        }
+        invokeAnyMethod(animation, "applyTransaction", new Object[0]);
+        Object background = readField(animation, "background");
+        if (background != null) {
+            invokeAnyMethod(background, "customizeStatusBarAppearance",
+                    new Object[]{Integer.valueOf((int) closingRect.top)});
+        }
+    }
+
+    protected void applyCrossActivityTransform(Object animation, Object leash,
+                                               RectF rect, float alpha)
+            throws Exception {
+        Method method = crossActivityApplyTransform;
+        if (method == null || !method.getDeclaringClass().isInstance(animation)) {
+            method = null;
+            for (Class<?> current = animation.getClass(); current != null;
+                 current = current.getSuperclass()) {
+                for (Method candidate : current.getDeclaredMethods()) {
+                    if ("applyTransform".equals(candidate.getName())
+                            && candidate.getParameterCount() == 5) {
+                        candidate.setAccessible(true);
+                        method = candidate;
+                        break;
+                    }
+                }
+                if (method != null) {
+                    break;
+                }
+            }
+            if (method == null) {
+                throw new NoSuchMethodException("applyTransform");
+            }
+            crossActivityApplyTransform = method;
+            crossActivityNoFling = method.getParameterTypes()[4].getEnumConstants()[0];
+        }
+        method.invoke(animation, leash, rect, Float.valueOf(alpha), null,
+                crossActivityNoFling);
+    }
+
+    protected void lerpRectF(RectF start, RectF target, float progress, RectF out) {
+        out.left = start.left + (target.left - start.left) * progress;
+        out.top = start.top + (target.top - start.top) * progress;
+        out.right = start.right + (target.right - start.right) * progress;
+        out.bottom = start.bottom + (target.bottom - start.bottom) * progress;
+    }
+
+    // Cubic ease-out: full speed at release for a continuous handoff from the finger,
+    // then a decisive settle — a critically damped closed form starts at zero velocity
+    // (a visible hitch at release) and crawls sub-pixel through its final stretch.
+    protected float miuixSlideSettleEase(float linearProgress) {
+        float remaining = 1.0f - Math.max(0.0f, Math.min(1.0f, linearProgress));
+        return 1.0f - remaining * remaining * remaining;
     }
 
     protected void hookBackPrepareTransitionReparent(ClassLoader classLoader) {
@@ -2032,7 +2497,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
     }
 
     protected ReturnHomeFinishTransferCandidate
-            captureReturnHomeFinishTransferCandidate(
+    captureReturnHomeFinishTransferCandidate(
             XposedInterface.Chain chain) throws Exception {
         Thread ownerThread = Thread.currentThread();
         if (!isReturnHomeFinishTransferReady()
@@ -2395,9 +2860,9 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
         }
         boolean preparedWallpaperMatches = preparedWallpaperExpected
                 ? preparedWallpaperLeash != null
-                && !surfacesAreSame(preparedWallpaperLeash, appLeash)
-                && !surfacesAreSame(preparedWallpaperLeash, homeLeash)
-                && !surfacesAreSame(preparedWallpaperLeash, elementLeash)
+                  && !surfacesAreSame(preparedWallpaperLeash, appLeash)
+                  && !surfacesAreSame(preparedWallpaperLeash, homeLeash)
+                  && !surfacesAreSame(preparedWallpaperLeash, elementLeash)
                 : preparedWallpaperLeash == null;
         if (preparedAppLeash == null || preparedHomeLeash == null
                 || !preparedWallpaperMatches
@@ -2804,7 +3269,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
     }
 
     protected void hookShellAnimationFinished(Class<?> controllerClass, String methodName,
-                                            String hookId, boolean optional)
+                                              String hookId, boolean optional)
             throws NoSuchMethodException {
         try {
             Method method = controllerClass.getDeclaredMethod(methodName);
@@ -3080,7 +3545,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
     }
 
     protected boolean isTrustedMiuiHomeBroadcastSender(Context context, int uid,
-                                                      String senderPackage) {
+                                                       String senderPackage) {
         if (context == null || uid == Process.INVALID_UID
                 || !MIUI_HOME.equals(senderPackage)) {
             return false;
@@ -3116,7 +3581,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
     }
 
     protected synchronized void updateMiuiOverviewState(boolean overviewVisible,
-                                                      String state, String source) {
+                                                        String state, String source) {
         long now = SystemClock.uptimeMillis();
         long pendingUntil = miuiOverviewDismissPendingUntilUptime;
         if (overviewVisible && pendingUntil > now) {
@@ -3240,7 +3705,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
     }
 
     protected void ensureBackInputInstalledFromHandler(Object edgeBackGestureHandler,
-                                                     String reason) {
+                                                       String reason) {
         if (!acceptingBackInputInstalls || edgeBackGestureHandler == null) {
             return;
         }

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiInputRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiInputRuntime.java
@@ -1,5 +1,6 @@
 package dev.codex.miuibackgesturehook.hooks.systemui;
 
+import dev.codex.miuibackgesturehook.PredictiveBackPreferences;
 import dev.codex.miuibackgesturehook.hooks.core.HookRuntimeCore;
 
 import android.animation.Animator;
@@ -92,6 +93,61 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
 
     protected final Map<Object, NativeBackInputMonitor> nativeInputMonitors =
             Collections.synchronizedMap(new WeakHashMap<>());
+
+    protected volatile SharedPreferences hyperOsIndicatorPreferences;
+    protected volatile boolean hyperOsIndicatorPreferencesFailureLogged;
+
+    protected boolean isHyperOsIndicatorEnabled() {
+        return readHyperOsBooleanPreference(
+                PredictiveBackPreferences.KEY_HYPEROS_INDICATOR,
+                PredictiveBackPreferences.DEFAULT_HYPEROS_INDICATOR);
+    }
+
+    protected boolean isHyperOsHapticsEnabled() {
+        return readHyperOsBooleanPreference(
+                PredictiveBackPreferences.KEY_HYPEROS_HAPTICS,
+                PredictiveBackPreferences.DEFAULT_HYPEROS_HAPTICS);
+    }
+
+    protected boolean isHyperOsHapticsEnhancedEnabled() {
+        return readHyperOsBooleanPreference(
+                PredictiveBackPreferences.KEY_HYPEROS_HAPTICS_ENHANCED,
+                PredictiveBackPreferences.DEFAULT_HYPEROS_HAPTICS_ENHANCED);
+    }
+
+    @Override
+    protected boolean isHyperOsSlideAnimationEnabled() {
+        return readHyperOsBooleanPreference(
+                PredictiveBackPreferences.KEY_HYPEROS_SLIDE_ANIMATION,
+                PredictiveBackPreferences.DEFAULT_HYPEROS_SLIDE_ANIMATION);
+    }
+
+    protected boolean readHyperOsBooleanPreference(String key, boolean defaultValue) {
+        try {
+            SharedPreferences preferences = hyperOsIndicatorPreferences;
+            if (preferences == null) {
+                synchronized (this) {
+                    preferences = hyperOsIndicatorPreferences;
+                    if (preferences == null) {
+                        preferences = getRemotePreferences(
+                                PredictiveBackPreferences.GROUP);
+                        hyperOsIndicatorPreferences = preferences;
+                    }
+                }
+            }
+            boolean enabled = preferences.getBoolean(key, defaultValue);
+            hyperOsIndicatorPreferencesFailureLogged = false;
+            return enabled;
+        } catch (Throwable throwable) {
+            if (!hyperOsIndicatorPreferencesFailureLogged) {
+                hyperOsIndicatorPreferencesFailureLogged = true;
+                log(Log.ERROR, TAG, "HyperOS indicator preference unavailable"
+                        + ", policy=failClosedToAospPanel"
+                        + ", key=" + key, throwable);
+            }
+            return false;
+        }
+    }
 
     protected boolean isOpenEndHandoffCurrent(long handoffEpoch) {
         return handoffEpoch != 0L
@@ -1184,6 +1240,11 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
         protected float downY;
         protected float lastX;
         protected float lastY;
+        protected MiuiStyleBackArrowOverlay miuiStyleOverlay;
+        protected MiuiHapticFeedbackHelper miuiHapticHelper;
+        protected boolean miuiStyleGestureActive;
+        protected boolean miuiStyleSwipeStarted;
+        protected boolean miuiStyleHapticsActive;
 
         SystemUiBackGestureDriver(Context context, Object edgeBackGestureHandler,
                                   Object controller, Object backAnimationImpl)
@@ -1776,6 +1837,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                 inputMonitorAttached = false;
                 inputMonitorEpoch.incrementAndGet();
             }
+            teardownMiuiStyleIndicator();
             if (pendingLauncherOpenBreakAttemptId != 0L) {
                 decrementLauncherOpenBreakCommandsInFlight();
             }
@@ -3305,10 +3367,32 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                 Object plugin = readField(edgeBackGestureHandler, "mEdgeBackPlugin");
                 if (plugin == null) {
                     log(Log.WARN, TAG, "NavigationEdgeBackPlugin is null; native panel unavailable");
+                    if (miuiStyleGestureActive) {
+                        miuiStyleGestureActive = false;
+                        MiuiStyleBackArrowOverlay overlay = miuiStyleOverlay;
+                        if (overlay != null && miuiStyleSwipeStarted) {
+                            overlay.onGestureEnd(-1.0f);
+                        }
+                        miuiStyleSwipeStarted = false;
+                        miuiStyleHapticsActive = false;
+                    }
                     return false;
                 }
                 if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
                     prepareNativeBackPanel(plugin);
+                    miuiStyleGestureActive = prepareMiuiStyleIndicator(edge)
+                            && applyNativePanelSkinVisibility(plugin, true);
+                    if (!miuiStyleGestureActive) {
+                        applyNativePanelSkinVisibility(plugin, false);
+                    }
+                    miuiStyleHapticsActive = miuiStyleGestureActive
+                            && prepareMiuiStyleHaptics();
+                    // May clear miuiStyleHapticsActive on failure, so the overlay must
+                    // learn the final value afterwards or both sources would vibrate.
+                    applyNativePanelHapticSuppression(plugin, miuiStyleHapticsActive);
+                    if (miuiStyleOverlay != null) {
+                        miuiStyleOverlay.setHapticsForGesture(miuiStyleHapticsActive);
+                    }
                 }
                 invokeMethod(plugin, "setIsLeftPanel",
                         new Class<?>[]{boolean.class},
@@ -3317,6 +3401,9 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                 screenEvent.setLocation(event.getRawX(), event.getRawY());
                 invokeMethod(plugin, "onMotionEvent",
                         new Class<?>[]{MotionEvent.class}, new Object[]{screenEvent});
+                if (miuiStyleGestureActive) {
+                    driveMiuiStyleIndicator(event, edge);
+                }
                 return true;
             } catch (Throwable throwable) {
                 log(Log.WARN, TAG, "Failed to dispatch event to NavigationEdgeBackPlugin",
@@ -3375,6 +3462,271 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             } catch (Throwable throwable) {
                 log(Log.WARN, TAG, "Failed to prepare native AOSP back panel", throwable);
             }
+        }
+
+        protected boolean prepareMiuiStyleIndicator(int edge) {
+            if (!isHyperOsIndicatorEnabled()) {
+                return false;
+            }
+            try {
+                if (miuiStyleOverlay == null) {
+                    miuiStyleOverlay = new MiuiStyleBackArrowOverlay(context,
+                            (priority, message, throwable) -> {
+                                if (throwable == null) {
+                                    log(priority, TAG, message);
+                                } else {
+                                    log(priority, TAG, message, throwable);
+                                }
+                            });
+                }
+                return miuiStyleOverlay.prepare(edge);
+            } catch (Throwable throwable) {
+                log(Log.WARN, TAG, "Failed to prepare HyperOS-style indicator",
+                        throwable);
+                return false;
+            }
+        }
+
+        /**
+         * The hidden native BackPanelController keeps processing every event for state,
+         * commit thresholds, and haptics; only its View pixels are suppressed while the
+         * HyperOS-style overlay draws. Restoring is best-effort and re-evaluated on the
+         * next ACTION_DOWN, so a failure here can never strand an invisible panel.
+         */
+        protected boolean applyNativePanelSkinVisibility(Object plugin, boolean hide) {
+            try {
+                Object panelView = readField(plugin, "mView");
+                if (!(panelView instanceof View)) {
+                    return false;
+                }
+                float alpha = hide ? 0.0f : 1.0f;
+                View target = (View) panelView;
+                if (target.getAlpha() != alpha) {
+                    target.setAlpha(alpha);
+                    log(Log.INFO, TAG, "Native BackPanel visuals "
+                            + (hide ? "hidden behind HyperOS-style indicator"
+                            : "restored"));
+                }
+                return true;
+            } catch (Throwable throwable) {
+                log(Log.WARN, TAG, "Failed to change native BackPanel visibility"
+                        + ", hide=" + hide, throwable);
+                return false;
+            }
+        }
+
+        protected void driveMiuiStyleIndicator(MotionEvent event, int edge) {
+            MiuiStyleBackArrowOverlay overlay = miuiStyleOverlay;
+            if (overlay == null) {
+                miuiStyleGestureActive = false;
+                miuiStyleSwipeStarted = false;
+                return;
+            }
+            try {
+                switch (event.getActionMasked()) {
+                    case MotionEvent.ACTION_DOWN:
+                        // Nothing is drawn yet: Xiaomi's processor waits for the 20px
+                        // horizontal intent threshold below before onSwipeStart().
+                        miuiStyleSwipeStarted = false;
+                        break;
+                    case MotionEvent.ACTION_MOVE: {
+                        float offset = miuiStyleGestureOffset(event, edge);
+                        if (!miuiStyleSwipeStarted) {
+                            // Mirrors GesturesBackTouchProcessor: horizontal delta must
+                            // reach 20px and dominate half the vertical delta first.
+                            float verticalDelta =
+                                    Math.abs(event.getRawY() - downY);
+                            if (offset < MIUI_STYLE_SWIPE_START_PX
+                                    || offset < verticalDelta / 2.0f) {
+                                break;
+                            }
+                            miuiStyleSwipeStarted = true;
+                            overlay.onGestureStart(downY, edge);
+                        }
+                        overlay.onGestureProgress(Math.max(0.0f, offset),
+                                offset > MIUI_STYLE_ARROW_SHOW_PX
+                                        && isNativePanelStateLit());
+                        break;
+                    }
+                    case MotionEvent.ACTION_UP: {
+                        float releaseOffset = Math.max(0.0f,
+                                miuiStyleGestureOffset(event, edge));
+                        // Snapshot before onGestureEnd() cancels the arrow animator,
+                        // mirroring Xiaomi reading isArrowFeedBackDone() pre-stop.
+                        boolean handUpEligible = miuiStyleHapticsActive
+                                && miuiStyleSwipeStarted;
+                        boolean arrowFeedbackDone = overlay.isArrowFeedbackDone();
+                        if (miuiStyleSwipeStarted) {
+                            overlay.onGestureEnd(releaseOffset);
+                        }
+                        if (handUpEligible) {
+                            maybePerformMiuiHandUpHaptic(event, releaseOffset,
+                                    arrowFeedbackDone);
+                        }
+                        miuiStyleGestureActive = false;
+                        miuiStyleSwipeStarted = false;
+                        miuiStyleHapticsActive = false;
+                        break;
+                    }
+                    case MotionEvent.ACTION_CANCEL:
+                        if (miuiStyleSwipeStarted) {
+                            overlay.onGestureEnd(-1.0f);
+                        }
+                        overlay.markArrowFeedbackDone();
+                        miuiStyleGestureActive = false;
+                        miuiStyleSwipeStarted = false;
+                        miuiStyleHapticsActive = false;
+                        break;
+                    default:
+                        break;
+                }
+            } catch (Throwable throwable) {
+                log(Log.WARN, TAG, "Failed to drive HyperOS-style indicator",
+                        throwable);
+                miuiStyleGestureActive = false;
+                miuiStyleSwipeStarted = false;
+            }
+        }
+
+        protected float miuiStyleGestureOffset(MotionEvent event, int edge) {
+            return edge == EDGE_LEFT
+                    ? event.getRawX() - downX
+                    : downX - event.getRawX();
+        }
+
+        // The arrow lights exactly when the hidden native panel would commit on release,
+        // so the HyperOS visuals stay truthful to the module's AOSP trigger semantics.
+        protected boolean isNativePanelStateLit() {
+            String state = readNativePanelState();
+            return "ACTIVE".equals(state) || "FLUNG".equals(state)
+                    || "COMMITTED".equals(state);
+        }
+
+        protected boolean prepareMiuiStyleHaptics() {
+            if (!isHyperOsHapticsEnabled()) {
+                return false;
+            }
+            try {
+                if (miuiHapticHelper == null) {
+                    miuiHapticHelper = new MiuiHapticFeedbackHelper(context,
+                            (priority, message, throwable) -> {
+                                if (throwable == null) {
+                                    log(priority, TAG, message);
+                                } else {
+                                    log(priority, TAG, message, throwable);
+                                }
+                            });
+                }
+                if (!miuiHapticHelper.isSupported()) {
+                    return false;
+                }
+                miuiHapticHelper.setEnhancedMode(isHyperOsHapticsEnhancedEnabled());
+                MiuiStyleBackArrowOverlay overlay = miuiStyleOverlay;
+                if (overlay != null) {
+                    overlay.setHapticListener(() -> {
+                        MiuiHapticFeedbackHelper helper = miuiHapticHelper;
+                        if (helper != null) {
+                            helper.performReadyBack();
+                        }
+                    });
+                }
+                return true;
+            } catch (Throwable throwable) {
+                log(Log.WARN, TAG, "Failed to prepare MIUI two-stage haptics",
+                        throwable);
+                return false;
+            }
+        }
+
+        /**
+         * Mirrors GestureStubView.onSwipeStop: hand-up plays only for a committed
+         * release under the native doFeedBack rule — a slow release on non-V2 devices
+         * or a ready-back haptic that never completed.
+         */
+        protected void maybePerformMiuiHandUpHaptic(MotionEvent event,
+                                                    float releaseOffset,
+                                                    boolean arrowFeedbackDone) {
+            MiuiHapticFeedbackHelper helper = miuiHapticHelper;
+            MiuiStyleBackArrowOverlay overlay = miuiStyleOverlay;
+            if (helper == null || overlay == null) {
+                return;
+            }
+            try {
+                Boolean panelTrigger = resolveNativePanelReleaseTrigger(
+                        readNativePanelState(), true);
+                if (Boolean.TRUE.equals(panelTrigger)) {
+                    long gestureDuration =
+                            event.getEventTime() - event.getDownTime();
+                    float pxPerMs = gestureDuration > 0
+                            ? releaseOffset / gestureDuration : 0.0f;
+                    // Enhanced mode plays hand-up on every committed release; the
+                    // helper's 140ms blocker still prevents doubles near ready-back.
+                    boolean doFeedback = helper.isEnhancedMode()
+                            || (!helper.isHapticV2() && pxPerMs < 2.0f)
+                            || !arrowFeedbackDone;
+                    if (doFeedback) {
+                        helper.performHandUp();
+                    }
+                }
+                overlay.markArrowFeedbackDone();
+            } catch (Throwable throwable) {
+                log(Log.WARN, TAG, "Failed to play MIUI hand-up haptic", throwable);
+            }
+        }
+
+        /**
+         * BackPanel plays its threshold haptics through View.performHapticFeedback on
+         * its own view, so isHapticFeedbackEnabled() suppresses exactly that feedback.
+         * On failure the two-stage haptics are disabled and the native feedback stays.
+         */
+        protected void applyNativePanelHapticSuppression(Object plugin,
+                                                         boolean suppress) {
+            try {
+                Object panelView = readField(plugin, "mView");
+                if (!(panelView instanceof View)) {
+                    if (suppress) {
+                        miuiStyleHapticsActive = false;
+                    }
+                    return;
+                }
+                View target = (View) panelView;
+                boolean enabled = !suppress;
+                if (target.isHapticFeedbackEnabled() != enabled) {
+                    target.setHapticFeedbackEnabled(enabled);
+                    log(Log.INFO, TAG, "Native BackPanel haptics "
+                            + (suppress ? "suppressed for MIUI two-stage haptics"
+                            : "restored"));
+                }
+            } catch (Throwable throwable) {
+                log(Log.WARN, TAG, "Failed to change native BackPanel haptics"
+                        + ", suppress=" + suppress, throwable);
+                if (suppress) {
+                    miuiStyleHapticsActive = false;
+                }
+            }
+        }
+
+        protected void teardownMiuiStyleIndicator() {
+            miuiStyleGestureActive = false;
+            miuiStyleSwipeStarted = false;
+            miuiStyleHapticsActive = false;
+            MiuiStyleBackArrowOverlay overlay = miuiStyleOverlay;
+            miuiStyleOverlay = null;
+            if (overlay != null) {
+                overlay.detach();
+            }
+            new Handler(Looper.getMainLooper()).post(() -> {
+                try {
+                    Object plugin = readField(edgeBackGestureHandler, "mEdgeBackPlugin");
+                    if (plugin != null) {
+                        applyNativePanelSkinVisibility(plugin, false);
+                        applyNativePanelHapticSuppression(plugin, false);
+                    }
+                } catch (Throwable throwable) {
+                    log(Log.WARN, TAG, "Failed to restore native BackPanel visuals",
+                            throwable);
+                }
+            });
         }
     }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -12,6 +12,14 @@
     <string name="predictive_back_loading_apps">正在加载应用…</string>
     <string name="predictive_back_no_apps">没有符合条件的应用</string>
     <string name="predictive_back_unavailable_app">已保存选择，但当前无法找到该应用</string>
+    <string name="hyperos_indicator_title">HyperOS 返回箭头</string>
+    <string name="hyperos_indicator_summary">以 HyperOS 样式指示器替代 AOSP 面板</string>
+    <string name="hyperos_haptics_title">HyperOS 手势震动</string>
+    <string name="hyperos_haptics_summary">两段式震动：箭头就绪与提交返回</string>
+    <string name="hyperos_haptics_enhanced_title">增强松手震感</string>
+    <string name="hyperos_haptics_enhanced_summary">提交返回必震，并使用独立的松手效果</string>
+    <string name="hyperos_slide_animation_title">HyperOS 侧滑返回动画</string>
+    <string name="hyperos_slide_animation_summary">以全宽侧滑替代 AOSP 预测性返回</string>
     <string name="back">返回</string>
     <string name="more_options">更多选项</string>
     <string name="toggle_dropdown">展开或收起下拉菜单</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,14 @@
     <string name="predictive_back_loading_apps">Loading apps…</string>
     <string name="predictive_back_no_apps">No matching apps</string>
     <string name="predictive_back_unavailable_app">Saved selection; app is currently unavailable</string>
+    <string name="hyperos_indicator_title">HyperOS back arrow</string>
+    <string name="hyperos_indicator_summary">Use the HyperOS-style indicator instead of the AOSP panel</string>
+    <string name="hyperos_haptics_title">HyperOS gesture haptics</string>
+    <string name="hyperos_haptics_summary">Two-stage haptics: arrow ready and committed release</string>
+    <string name="hyperos_haptics_enhanced_title">Enhanced release haptic</string>
+    <string name="hyperos_haptics_enhanced_summary">Always vibrate on commit, with a distinct release effect</string>
+    <string name="hyperos_slide_animation_title">HyperOS slide-back animation</string>
+    <string name="hyperos_slide_animation_summary">Full-width slide instead of the AOSP predictive back</string>
     <string name="back">Back</string>
     <string name="more_options">More options</string>
     <string name="toggle_dropdown">Toggle dropdown</string>


### PR DESCRIPTION
Three opt-in restyles of the SystemUI-side predictive back, all gated behind remote preferences (default off); return-to-home stays untouched.

- Back arrow: draw a visual-only port of MiuiHome's GestureBackArrowView in a non-touchable overlay, bitmaps loaded from com.miui.home. The native BackPanelController still owns state, thresholds, and commit; arrow lights on its ACTIVE/FLUNG/COMMITTED state and Xiaomi's 180px rule. Fails closed.
- Gesture haptics: reproduce the two-stage back haptics through the framework miui.util.HapticFeedbackUtil (ready-back / hand-up), suppressing the native panel's threshold feedback. Optional enhanced mode always vibrates on commit with a distinct release effect.
- Slide-back animation: restyle the cross-activity/cross-task predictive back into the miuix full-width slide. Drag follows the finger linearly via the framework BackProgressAnimator callback (R8 inlines the private method), the commit settles on a cubic ease-out to the full slide-out, the revealed layer's dim scrim tracks the drag, and its corner radius is cleared.