### PR TITLE
feat: 扩展预测性返回兼容性并支持自定义动画背景

### DIFF
--- a/app/src/main/java/dev/codex/miuibackgesturehook/PredictiveBackPreferences.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/PredictiveBackPreferences.java
@@ -16,9 +16,15 @@ public final class PredictiveBackPreferences {
     public static final String KEY_HYPEROS_SLIDE_ANIMATION =
             "hyperos_slide_back_animation";
     public static final boolean DEFAULT_HYPEROS_SLIDE_ANIMATION = false;
+    public static final String KEY_AOSP_BACKGROUND_MODE = "aosp_background_mode";
+    public static final int AOSP_BACKGROUND_SYSTEM = 0;
+    public static final int AOSP_BACKGROUND_BLACK = 1;
+    public static final int AOSP_BACKGROUND_WALLPAPER = 2;
+    public static final int DEFAULT_AOSP_BACKGROUND_MODE = AOSP_BACKGROUND_SYSTEM;
+    public static final String KEY_AOSP_WALLPAPER_BLUR = "aosp_wallpaper_blur";
+    public static final boolean DEFAULT_AOSP_WALLPAPER_BLUR = false;
     public static final String KEY_MODULE_LOGGING = "module_logging";
     public static final boolean DEFAULT_MODULE_LOGGING = true;
-
     /** The vertical size of both Xiaomi side trigger areas, expressed as a percentage. */
     public static final String KEY_GESTURE_TRIGGER_HEIGHT_PERCENT =
             "gesture_trigger_height_percent";
@@ -34,5 +40,9 @@ public final class PredictiveBackPreferences {
     public static final int MAX_GESTURE_TRIGGER_POSITION_PERCENT = 100;
 
     private PredictiveBackPreferences() {
+    }
+
+    public static boolean isValidAospBackgroundMode(int mode) {
+        return mode >= AOSP_BACKGROUND_SYSTEM && mode <= AOSP_BACKGROUND_WALLPAPER;
     }
 }

--- a/app/src/main/java/dev/codex/miuibackgesturehook/activity/PredictiveBackSettingsActivity.kt
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/activity/PredictiveBackSettingsActivity.kt
@@ -157,6 +157,18 @@ private fun PredictiveBackSettingsScreen(
     var confirmedHyperOsHapticsEnhanced by remember { mutableStateOf(false) }
     var hyperOsSlideAnimation by remember { mutableStateOf(false) }
     var confirmedHyperOsSlideAnimation by remember { mutableStateOf(false) }
+    var aospBackgroundMode by remember {
+        mutableStateOf(PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE)
+    }
+    var confirmedAospBackgroundMode by remember {
+        mutableStateOf(PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE)
+    }
+    var aospWallpaperBlur by remember {
+        mutableStateOf(PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR)
+    }
+    var confirmedAospWallpaperBlur by remember {
+        mutableStateOf(PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR)
+    }
     var moduleLogging by remember { mutableStateOf(true) }
     var confirmedModuleLogging by remember { mutableStateOf(true) }
     val writeMutex = remember(preferences) { Mutex() }
@@ -180,6 +192,12 @@ private fun PredictiveBackSettingsScreen(
         confirmedHyperOsHapticsEnhanced = false
         hyperOsSlideAnimation = false
         confirmedHyperOsSlideAnimation = false
+        aospBackgroundMode = PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE
+        confirmedAospBackgroundMode =
+            PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE
+        aospWallpaperBlur = PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR
+        confirmedAospWallpaperBlur =
+            PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR
         moduleLogging = PredictiveBackPreferences.DEFAULT_MODULE_LOGGING
         confirmedModuleLogging = PredictiveBackPreferences.DEFAULT_MODULE_LOGGING
         if (!serviceStateObserved) {
@@ -234,8 +252,25 @@ private fun PredictiveBackSettingsScreen(
                         PredictiveBackPreferences.KEY_MODULE_LOGGING,
                         PredictiveBackPreferences.DEFAULT_MODULE_LOGGING,
                     ),
+                    remotePreferences.getBoolean(
+                        PredictiveBackPreferences.KEY_AOSP_WALLPAPER_BLUR,
+                        PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR,
+                    ),
                 )
-                remotePreferences to flags
+                val storedAospBackgroundMode = remotePreferences.getInt(
+                    PredictiveBackPreferences.KEY_AOSP_BACKGROUND_MODE,
+                    PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE,
+                )
+                val aospBackgroundMode = if (
+                    PredictiveBackPreferences.isValidAospBackgroundMode(
+                        storedAospBackgroundMode,
+                    )
+                ) {
+                    storedAospBackgroundMode
+                } else {
+                    PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE
+                }
+                Triple(remotePreferences, flags, aospBackgroundMode)
             }
             preferences = loaded.first
             hyperOsIndicator = loaded.second[0]
@@ -246,8 +281,12 @@ private fun PredictiveBackSettingsScreen(
             confirmedHyperOsHapticsEnhanced = loaded.second[2]
             hyperOsSlideAnimation = loaded.second[3]
             confirmedHyperOsSlideAnimation = loaded.second[3]
+            aospBackgroundMode = loaded.third
+            confirmedAospBackgroundMode = loaded.third
             moduleLogging = loaded.second[4]
             confirmedModuleLogging = loaded.second[4]
+            aospWallpaperBlur = loaded.second[5]
+            confirmedAospWallpaperBlur = loaded.second[5]
         } catch (_: Throwable) {
             configurationError = configurationErrorMessage
         } finally {
@@ -345,6 +384,61 @@ private fun PredictiveBackSettingsScreen(
             { confirmedModuleLogging = it },
         )
     }
+    val persistAospWallpaperBlur: (Boolean) -> Unit = { requestedEnabled ->
+        persistBooleanPreference(
+            PredictiveBackPreferences.KEY_AOSP_WALLPAPER_BLUR,
+            requestedEnabled,
+            { aospWallpaperBlur = it },
+            { confirmedAospWallpaperBlur },
+            { confirmedAospWallpaperBlur = it },
+        )
+    }
+    val persistAospBackgroundMode: (Int) -> Unit = persistMode@{ requestedMode ->
+        if (!PredictiveBackPreferences.isValidAospBackgroundMode(requestedMode)) {
+            return@persistMode
+        }
+        val activePreferences = preferences ?: return@persistMode
+        aospBackgroundMode = requestedMode
+        saveError = null
+        scope.launch {
+            val saved = writeMutex.withLock {
+                val fallbackMode = confirmedAospBackgroundMode
+                val commitSucceeded = withContext(Dispatchers.IO) {
+                    val succeeded = try {
+                        activePreferences.edit()
+                            .putInt(
+                                PredictiveBackPreferences.KEY_AOSP_BACKGROUND_MODE,
+                                requestedMode,
+                            )
+                            .commit()
+                    } catch (_: Throwable) {
+                        false
+                    }
+                    if (!succeeded) {
+                        try {
+                            activePreferences.edit()
+                                .putInt(
+                                    PredictiveBackPreferences.KEY_AOSP_BACKGROUND_MODE,
+                                    fallbackMode,
+                                )
+                                .commit()
+                        } catch (_: Throwable) {
+                            // Restore the RemotePreferences cache where possible.
+                        }
+                    }
+                    succeeded
+                }
+                if (preferences === activePreferences && commitSucceeded) {
+                    confirmedAospBackgroundMode = requestedMode
+                }
+                commitSucceeded
+            }
+            if (preferences === activePreferences && !saved) {
+                aospBackgroundMode = confirmedAospBackgroundMode
+                saveError = saveErrorMessage
+            }
+        }
+    }
     val statusMessage = when {
         configurationLoading -> SettingsStatusCardMessage(
             text = serviceLoadingMessage,
@@ -428,6 +522,19 @@ private fun PredictiveBackSettingsScreen(
                     moduleLogging = moduleLogging,
                     configurationEnabled = configurationEnabled,
                     onModuleLoggingToggle = persistModuleLogging,
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp)
+                        .padding(bottom = 8.dp),
+                )
+            }
+            item(key = "aosp_background") {
+                AospBackgroundCard(
+                    backgroundMode = aospBackgroundMode,
+                    wallpaperBlur = aospWallpaperBlur,
+                    configurationEnabled = configurationEnabled,
+                    hyperOsSlideAnimation = hyperOsSlideAnimation,
+                    onBackgroundModeChange = persistAospBackgroundMode,
+                    onWallpaperBlurToggle = persistAospWallpaperBlur,
                     modifier = Modifier
                         .padding(horizontal = 12.dp)
                         .padding(bottom = 8.dp),
@@ -594,6 +701,64 @@ private fun ModuleLoggingCard(
             checked = moduleLogging,
             enabled = configurationEnabled,
             onCheckedChange = onModuleLoggingToggle,
+        )
+    }
+}
+
+@Composable
+private fun AospBackgroundCard(
+    backgroundMode: Int,
+    wallpaperBlur: Boolean,
+    configurationEnabled: Boolean,
+    hyperOsSlideAnimation: Boolean,
+    onBackgroundModeChange: (Int) -> Unit,
+    onWallpaperBlurToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val switchesEnabled = configurationEnabled && !hyperOsSlideAnimation
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        insideMargin = PaddingValues(0.dp),
+    ) {
+        SwitchPreference(
+            title = stringResource(R.string.aosp_background_black_title),
+            summary = stringResource(R.string.aosp_background_black_summary),
+            checked = backgroundMode ==
+                PredictiveBackPreferences.AOSP_BACKGROUND_BLACK,
+            enabled = switchesEnabled,
+            onCheckedChange = { checked ->
+                onBackgroundModeChange(
+                    if (checked) {
+                        PredictiveBackPreferences.AOSP_BACKGROUND_BLACK
+                    } else {
+                        PredictiveBackPreferences.AOSP_BACKGROUND_SYSTEM
+                    },
+                )
+            },
+        )
+        SwitchPreference(
+            title = stringResource(R.string.aosp_background_wallpaper_title),
+            summary = stringResource(R.string.aosp_background_wallpaper_summary),
+            checked = backgroundMode ==
+                PredictiveBackPreferences.AOSP_BACKGROUND_WALLPAPER,
+            enabled = switchesEnabled,
+            onCheckedChange = { checked ->
+                onBackgroundModeChange(
+                    if (checked) {
+                        PredictiveBackPreferences.AOSP_BACKGROUND_WALLPAPER
+                    } else {
+                        PredictiveBackPreferences.AOSP_BACKGROUND_SYSTEM
+                    },
+                )
+            },
+        )
+        SwitchPreference(
+            title = stringResource(R.string.aosp_wallpaper_blur_title),
+            summary = stringResource(R.string.aosp_wallpaper_blur_summary),
+            checked = wallpaperBlur,
+            enabled = switchesEnabled && backgroundMode ==
+                PredictiveBackPreferences.AOSP_BACKGROUND_WALLPAPER,
+            onCheckedChange = onWallpaperBlurToggle,
         )
     }
 }

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
@@ -126,6 +126,8 @@ public abstract class HookRuntimeCore extends XposedModule {
             "com.miui.home.recents.anim.StateManager$windowElementAnimListener$1";
     protected static final String MIUI_HOME_STATE_MANAGER =
             "com.miui.home.recents.anim.StateManager";
+    protected static final String MIUI_HOME_WIDGET_CLICK_EVENT_INFO =
+            "com.miui.home.recents.event.WidgetClickEventInfo";
     protected static final String MIUI_HOME_WINDOW_ELEMENT =
             "com.miui.home.recents.anim.WindowElement";
     protected static final String MIUI_HOME_REMOTE_TRANSITION_INFO =
@@ -152,6 +154,8 @@ public abstract class HookRuntimeCore extends XposedModule {
             "com.miui.home.launcher.Application";
     protected static final String MIUI_HOME_OVERVIEW_PROXY_IMPL =
             "com.miui.home.recents.OverviewProxyImpl";
+    protected static final String MIUI_HOME_TOUCH_INTERACTION_OVERVIEW_PROXY =
+            "com.miui.home.recents.TouchInteractionService$1";
     protected static final String MIUI_HOME_REMOTE_ANIMATION_TARGET_COMPAT =
             "com.android.systemui.shared.recents.system.RemoteAnimationTargetCompat";
     protected static final String MIUI_HOME_REMOTE_ANIMATION_TARGET_SET =
@@ -226,9 +230,6 @@ public abstract class HookRuntimeCore extends XposedModule {
             "com.android.wm.shell.back.DefaultCrossActivityBackAnimation";
     protected static final String BACK_ANIMATION_BACKGROUND =
             "com.android.wm.shell.back.BackAnimationBackground";
-    // The hard-coded color CrossTaskBackAnimation passes to ensureBackground (0x43433A);
-    // used to distinguish its background from cross-activity's task-colored one.
-    protected static final int CROSS_TASK_BACKGROUND_COLOR = 4408122;
     protected static final String BACK_TRANSITION_HANDLER =
             "com.android.wm.shell.back.BackAnimationController$BackTransitionHandler";
     protected static final String DEFAULT_TRANSITION_HANDLER =
@@ -283,6 +284,8 @@ public abstract class HookRuntimeCore extends XposedModule {
     protected static final String EXTRA_INPUT_SOURCE = "input_source";
     protected static final String EXTRA_INPUT_DISPLAY_ID = "input_display_id";
     protected static final String EXTRA_INPUT_EDGE = "input_edge";
+    protected static final String EXTRA_LAUNCHER_OVERVIEW_ACTIVE =
+            "launcher_overview_active";
     protected static final String EXTRA_LAUNCHER_OPEN_BREAK_AVAILABLE =
             "launcher_open_break_available";
     protected static final String EXTRA_LAUNCHER_OPEN_ACTIVE =
@@ -337,7 +340,6 @@ public abstract class HookRuntimeCore extends XposedModule {
     protected static final float AOSP_PROGRESS_THRESHOLD_DP = 412.0f;
     protected static final float RETURN_HOME_MIN_WINDOW_SCALE = 0.85f;
     protected static final float RETURN_HOME_WINDOW_MARGIN_DP = 8.0f;
-    protected static final float RETURN_HOME_END_CORNER_RADIUS_DP = 28.0f;
     protected static final String MIUI_SIDEBAR_BOUNDS = "sidebar_bounds";
     protected static final float MIUI_SIDEBAR_EXCLUSION_PADDING_DP = 8.0f;
     protected static final long MIUI_OVERVIEW_DISMISS_TIMEOUT_MS = 2500L;
@@ -474,16 +476,38 @@ public abstract class HookRuntimeCore extends XposedModule {
     protected volatile boolean predictiveBackApplicationMetadataFailureLogged;
     protected volatile boolean moduleLoggingEnabled =
             PredictiveBackPreferences.DEFAULT_MODULE_LOGGING;
+    protected volatile int aospBackgroundMode =
+            PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE;
+    protected volatile boolean aospWallpaperBlurEnabled =
+            PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR;
+    protected volatile boolean cachedHyperOsSlideAnimationEnabled =
+            PredictiveBackPreferences.DEFAULT_HYPEROS_SLIDE_ANIMATION;
     protected volatile SharedPreferences moduleLoggingPreferences;
     private final SharedPreferences.OnSharedPreferenceChangeListener
             moduleLoggingPreferenceListener = (preferences, key) -> {
-                if (!PredictiveBackPreferences.KEY_MODULE_LOGGING.equals(key)) {
+                if (!PredictiveBackPreferences.KEY_MODULE_LOGGING.equals(key)
+                        && !PredictiveBackPreferences.KEY_AOSP_BACKGROUND_MODE.equals(key)
+                        && !PredictiveBackPreferences.KEY_AOSP_WALLPAPER_BLUR.equals(key)
+                        && !PredictiveBackPreferences.KEY_HYPEROS_SLIDE_ANIMATION.equals(key)) {
                     return;
                 }
                 try {
                     moduleLoggingEnabled = preferences.getBoolean(
                             PredictiveBackPreferences.KEY_MODULE_LOGGING,
                             PredictiveBackPreferences.DEFAULT_MODULE_LOGGING);
+                    int mode = preferences.getInt(
+                            PredictiveBackPreferences.KEY_AOSP_BACKGROUND_MODE,
+                            PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE);
+                    aospBackgroundMode = PredictiveBackPreferences
+                            .isValidAospBackgroundMode(mode)
+                            ? mode
+                            : PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE;
+                    aospWallpaperBlurEnabled = preferences.getBoolean(
+                            PredictiveBackPreferences.KEY_AOSP_WALLPAPER_BLUR,
+                            PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR);
+                    cachedHyperOsSlideAnimationEnabled = preferences.getBoolean(
+                            PredictiveBackPreferences.KEY_HYPEROS_SLIDE_ANIMATION,
+                            PredictiveBackPreferences.DEFAULT_HYPEROS_SLIDE_ANIMATION);
                 } catch (Throwable ignored) {
                     // Keep the last known logging policy when the remote preference is unreadable.
                 }
@@ -495,6 +519,8 @@ public abstract class HookRuntimeCore extends XposedModule {
     protected volatile Field defaultTransitionAnimationSizeField;
     protected volatile Field defaultTransitionAnimExecutorField;
     protected volatile Method animatorCanReverseMethod;
+    protected final ConcurrentHashMap<String, Boolean> windowFlagValues =
+            new ConcurrentHashMap<>();
     protected LegacyBackAttempt legacyBackAttempt;
     protected int legacyBackGuardPhase = BACK_GUARD_IDLE;
     protected long legacyBackGuardDeadlineUptime;
@@ -943,8 +969,27 @@ public abstract class HookRuntimeCore extends XposedModule {
             moduleLoggingEnabled = preferences.getBoolean(
                     PredictiveBackPreferences.KEY_MODULE_LOGGING,
                     PredictiveBackPreferences.DEFAULT_MODULE_LOGGING);
+            int mode = preferences.getInt(
+                    PredictiveBackPreferences.KEY_AOSP_BACKGROUND_MODE,
+                    PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE);
+            aospBackgroundMode = PredictiveBackPreferences
+                    .isValidAospBackgroundMode(mode)
+                    ? mode
+                    : PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE;
+            aospWallpaperBlurEnabled = preferences.getBoolean(
+                    PredictiveBackPreferences.KEY_AOSP_WALLPAPER_BLUR,
+                    PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR);
+            cachedHyperOsSlideAnimationEnabled = preferences.getBoolean(
+                    PredictiveBackPreferences.KEY_HYPEROS_SLIDE_ANIMATION,
+                    PredictiveBackPreferences.DEFAULT_HYPEROS_SLIDE_ANIMATION);
         } catch (Throwable ignored) {
             moduleLoggingEnabled = PredictiveBackPreferences.DEFAULT_MODULE_LOGGING;
+            aospBackgroundMode =
+                    PredictiveBackPreferences.DEFAULT_AOSP_BACKGROUND_MODE;
+            aospWallpaperBlurEnabled =
+                    PredictiveBackPreferences.DEFAULT_AOSP_WALLPAPER_BLUR;
+            cachedHyperOsSlideAnimationEnabled =
+                    PredictiveBackPreferences.DEFAULT_HYPEROS_SLIDE_ANIMATION;
         }
     }
 
@@ -1056,11 +1101,33 @@ public abstract class HookRuntimeCore extends XposedModule {
         public final int displayId;
         public final int edge;
         public final long generation;
+        public final boolean launcherOpenActive;
+        public final long launcherOpenGeneration;
+        public final boolean launcherOverviewActive;
         public final long receivedUptime;
 
         public MiuiHomeAcceptedInputToken(int eventId, long downTime, int deviceId,
                                           int source, int displayId, int edge,
                                           long generation) {
+            this(eventId, downTime, deviceId, source, displayId, edge,
+                    generation, false, 0L, false);
+        }
+
+        public MiuiHomeAcceptedInputToken(int eventId, long downTime, int deviceId,
+                                          int source, int displayId, int edge,
+                                          long generation,
+                                          boolean launcherOpenActive,
+                                          long launcherOpenGeneration) {
+            this(eventId, downTime, deviceId, source, displayId, edge,
+                    generation, launcherOpenActive, launcherOpenGeneration, false);
+        }
+
+        public MiuiHomeAcceptedInputToken(int eventId, long downTime, int deviceId,
+                                          int source, int displayId, int edge,
+                                          long generation,
+                                          boolean launcherOpenActive,
+                                          long launcherOpenGeneration,
+                                          boolean launcherOverviewActive) {
             this.eventId = eventId;
             this.downTime = downTime;
             this.deviceId = deviceId;
@@ -1068,6 +1135,9 @@ public abstract class HookRuntimeCore extends XposedModule {
             this.displayId = displayId;
             this.edge = edge;
             this.generation = generation;
+            this.launcherOpenActive = launcherOpenActive;
+            this.launcherOpenGeneration = launcherOpenGeneration;
+            this.launcherOverviewActive = launcherOverviewActive;
             this.receivedUptime = SystemClock.uptimeMillis();
         }
 
@@ -1082,6 +1152,10 @@ public abstract class HookRuntimeCore extends XposedModule {
 
     protected boolean readWindowFlag(String methodName, ClassLoader preferredLoader,
                                      boolean defaultValue) {
+        Boolean cached = windowFlagValues.get(methodName);
+        if (cached != null) {
+            return cached.booleanValue();
+        }
         String[] classNames = new String[]{
                 "com.android.window.flags.Flags",
                 "com.android.internal.hidden_from_bootclasspath.com.android.window.flags.Flags",
@@ -1094,9 +1168,12 @@ public abstract class HookRuntimeCore extends XposedModule {
                 method.setAccessible(true);
                 Object result = method.invoke(null);
                 if (result instanceof Boolean) {
+                    boolean value = ((Boolean) result).booleanValue();
+                    windowFlagValues.putIfAbsent(methodName,
+                            Boolean.valueOf(value));
                     moduleLog(Log.INFO, TAG, "Read " + methodName + " from "
                             + className + ": " + result);
-                    return ((Boolean) result).booleanValue();
+                    return value;
                 }
             } catch (Throwable throwable) {
                 moduleLog(Log.WARN, TAG, "Flag lookup failed for " + className
@@ -1106,6 +1183,8 @@ public abstract class HookRuntimeCore extends XposedModule {
         }
         moduleLog(Log.WARN, TAG, "Unable to read " + methodName
                 + "; defaulting to " + defaultValue);
+        windowFlagValues.putIfAbsent(methodName,
+                Boolean.valueOf(defaultValue));
         return defaultValue;
     }
 

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/hotreload/HotReloadHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/hotreload/HotReloadHookRuntime.java
@@ -391,8 +391,12 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
                         !oldHookIds.contains("systemui_back_slide_finish"),
                         !oldHookIds.contains("systemui_back_color_root_apply"));
             }
-            if (!oldHookIds.contains("systemui_cross_task_background")) {
-                hookCrossTaskBackground(hotReloadClassLoader);
+            if (!oldHookIds.contains("systemui_predictive_background_remove")
+                    || (!oldHookIds.contains(
+                    "systemui_predictive_background_ensure_4")
+                    && !oldHookIds.contains(
+                    "systemui_predictive_background_ensure_6"))) {
+                hookPredictiveBackBackground(hotReloadClassLoader);
             }
             if (!backCommitCompositionHookReady) {
                 hookBackCommitComposition(hotReloadClassLoader);
@@ -546,6 +550,9 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
                 if (!oldHookIds.contains("miui_home_return_home_fresh_open")) {
                     hookMiuiHomeReturnHomeFreshOpen(hotReloadClassLoader);
                 }
+                if (!oldHookIds.contains("miui_home_widget_open_shell_barrier")) {
+                    hookMiuiHomeWidgetOpenBarrier(hotReloadClassLoader);
+                }
                 if (!oldHookIds.contains("miui_home_return_home_cancel_direct")) {
                     hookMiuiHomeReturnHomeDirectCancel(hotReloadClassLoader);
                 }
@@ -657,6 +664,8 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
                 return this::routeMiuiHomeReturnHomeSameIconParallel;
             case "miui_home_return_home_fresh_open":
                 return this::forceMiuiHomeReturnHomeFreshOpen;
+            case "miui_home_widget_open_shell_barrier":
+                return this::deferMiuiHomeWidgetOpenUntilShellCleanup;
             case "miui_home_return_home_cancel_direct":
                 return this::wrapMiuiHomeReturnHomeDirectCancel;
             case "miui_home_drawer_state":
@@ -707,7 +716,11 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
             case "systemui_back_color_root_scrim_creation":
                 return this::keepFreeformScrimHiddenUntilFirstApply;
             case "systemui_cross_task_background":
-                return this::tintCrossTaskBackground;
+            case "systemui_predictive_background_ensure_4":
+            case "systemui_predictive_background_ensure_6":
+                return this::customizePredictiveBackBackground;
+            case "systemui_predictive_background_remove":
+                return this::removePredictiveBackBackground;
             case "systemui_back_prepare_reparent":
                 return this::correctPredictiveBackPrepareReparent;
             case "systemui_back_prepared_target_arrival":
@@ -964,6 +977,7 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
                     Collections.emptySet());
             hookMiuiHomeReturnHomeSameIconParallel(classLoader);
             hookMiuiHomeReturnHomeFreshOpen(classLoader);
+            hookMiuiHomeWidgetOpenBarrier(classLoader);
             hookMiuiHomeReturnHomeDirectCancel(classLoader);
             hookMiuiHomeDrawerState(classLoader);
             hookMiuiHomeFreeformBackTouchability(classLoader);

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
@@ -37,8 +37,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.github.libxposed.api.XposedInterface;
@@ -48,6 +50,15 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
     protected final Object miuiHomeGestureTriggerStubLock = new Object();
     protected final Set<View> miuiHomeGestureTriggerStubs =
             Collections.newSetFromMap(new WeakHashMap<>());
+    protected final Map<Object, Long> miuiHomeNativeInputStreams =
+            new ConcurrentHashMap<>();
+    protected volatile Method miuiHomeGetLauncherMethod;
+    protected volatile Method miuiHomeIsFolderOpenedMethod;
+    protected volatile Method miuiHomeIsInStateMethod;
+    protected volatile Object miuiHomeOverviewState;
+    protected volatile boolean miuiHomeFolderProbeFailureLogged;
+    protected volatile boolean miuiHomeOverviewProbeFailureLogged;
+    protected volatile boolean miuiHomeLauncherOverviewAtLastDown;
     protected volatile SharedPreferences miuiHomeGestureTriggerPreferences;
     protected volatile boolean miuiHomeGestureTriggerPreferenceFailureLogged;
     protected volatile boolean miuiHomeGestureTriggerTouchRegionFailureLogged;
@@ -137,16 +148,36 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 .intercept(this::mirrorMiuiHomeFullscreenState));
     }
 
-    protected void hookMiuiHomeReturnHomeInitialize(ClassLoader classLoader)
-            throws ClassNotFoundException, NoSuchMethodException {
-        Class<?> overviewProxyClass = Class.forName(MIUI_HOME_OVERVIEW_PROXY_IMPL, false,
-                classLoader);
-        Method method = overviewProxyClass.getDeclaredMethod(
-                "lambda$onInitialize$0", Bundle.class);
-        method.setAccessible(true);
-        recordHookHandle(hook(method)
-                .setId("miui_home_return_home_initialize")
-                .intercept(this::registerMiuiHomeReturnHome));
+    protected void hookMiuiHomeReturnHomeInitialize(ClassLoader classLoader) {
+        String[] proxyClasses = {
+                MIUI_HOME_OVERVIEW_PROXY_IMPL,
+                MIUI_HOME_TOUCH_INTERACTION_OVERVIEW_PROXY
+        };
+        Throwable lastFailure = null;
+        for (String proxyClassName : proxyClasses) {
+            try {
+                Class<?> overviewProxyClass = Class.forName(
+                        proxyClassName, false, classLoader);
+                Method method = overviewProxyClass.getDeclaredMethod(
+                        "lambda$onInitialize$0", Bundle.class);
+                method.setAccessible(true);
+                recordHookHandle(hook(method)
+                        .setId("miui_home_return_home_initialize")
+                        .intercept(this::registerMiuiHomeReturnHome));
+                moduleLog(Log.INFO, TAG,
+                        "Hooked MiuiHome return-home initialization via "
+                                + proxyClassName);
+                return;
+            } catch (Throwable throwable) {
+                lastFailure = throwable;
+            }
+        }
+        // This hook enriches return-to-home animation continuity. Its absence must not
+        // abort installation of input arbitration, folder back, or the later local hooks.
+        moduleLog(Log.WARN, TAG,
+                "MiuiHome return-home initialization class is unavailable; "
+                        + "continuing input-hook installation",
+                lastFailure);
     }
 
     protected void hookMiuiHomeReturnHomeLocalHandoff(ClassLoader classLoader)
@@ -561,6 +592,23 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 .intercept(this::forceMiuiHomeReturnHomeFreshOpen));
         moduleLog(Log.INFO, TAG,
                 "Hooked Xiaomi non-reusable same-icon fresh OPEN selection");
+    }
+
+    protected void hookMiuiHomeWidgetOpenBarrier(ClassLoader classLoader)
+            throws ClassNotFoundException, NoSuchMethodException {
+        Class<?> stateManagerClass = Class.forName(
+                MIUI_HOME_STATE_MANAGER, false, classLoader);
+        Class<?> widgetEventClass = Class.forName(
+                MIUI_HOME_WIDGET_CLICK_EVENT_INFO, false, classLoader);
+        Method method = stateManagerClass.getDeclaredMethod(
+                "onLauncherStartActivity", Intent.class, Object.class,
+                View.class, widgetEventClass);
+        method.setAccessible(true);
+        recordHookHandle(hook(method)
+                .setId("miui_home_widget_open_shell_barrier")
+                .intercept(this::deferMiuiHomeWidgetOpenUntilShellCleanup));
+        moduleLog(Log.INFO, TAG,
+                "Hooked Xiaomi widget OPEN Shell-cleanup barrier");
     }
 
     protected void hookMiuiHomeDrawerState(ClassLoader classLoader)
@@ -1825,7 +1873,8 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
         }
         try {
             if (controller.shouldForceFreshOpenAfterSameIconClose(
-                    chain.getThisObject(), chain.getArg(0), chain.getArg(2))) {
+                    chain.getThisObject(), chain.getArg(0),
+                    chain.getArg(2))) {
                 return Boolean.FALSE;
             }
         } catch (Throwable throwable) {
@@ -1837,6 +1886,41 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                     throwable);
         }
         return originalResult;
+    }
+
+    protected Object deferMiuiHomeWidgetOpenUntilShellCleanup(
+            XposedInterface.Chain chain) throws Throwable {
+        MiuiHomeReturnHomeController controller = miuiHomeReturnHomeController;
+        if (controller == null) {
+            return chain.proceed();
+        }
+        MiuiHomeReturnHomeController.ReturnHomeWidgetOpenBarrierToken token;
+        try {
+            token = controller.prepareWidgetOpenBarrier(
+                    chain.getThisObject(), chain.getArgs().toArray());
+        } catch (Throwable throwable) {
+            moduleLog(Log.WARN, TAG,
+                    "Failed to inspect Xiaomi widget OPEN cleanup boundary",
+                    throwable);
+            return chain.proceed();
+        }
+        if (token == null) {
+            return chain.proceed();
+        }
+        if (!token.resumeEntered.get()) {
+            // onLauncherStartActivity returns void. The exact invocation is retained by the
+            // controller and re-entered after the matching Shell finish signal arrives.
+            return null;
+        }
+        Throwable failure = null;
+        try {
+            return chain.proceed();
+        } catch (Throwable throwable) {
+            failure = throwable;
+            throw throwable;
+        } finally {
+            controller.completeWidgetOpenBarrierInvocation(token, failure);
+        }
     }
 
     protected Object wrapMiuiHomeReturnHomeDirectCancel(
@@ -2691,6 +2775,7 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 || !retiredController.deferredControllerReplacement
                 || retiredController.currentSession != null
                 || retiredController.pendingLauncherOpenBarrier.get() != null
+                || retiredController.pendingWidgetOpenBarrier.get() != null
                 || !retiredController
                 .pendingUnifiedInterruptedAnimToConfigs.isEmpty()) {
             return;
@@ -2813,7 +2898,8 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 + ", ordered=true");
     }
 
-    protected Object arbitrateMiuiHomeAcceptedInput(XposedInterface.Chain chain) {
+    protected Object arbitrateMiuiHomeAcceptedInput(XposedInterface.Chain chain)
+            throws Throwable {
         Object eventObject = chain.getArg(0);
         Object stubObject = chain.getArg(1);
         if (!(eventObject instanceof MotionEvent) || !(stubObject instanceof View)) {
@@ -2824,8 +2910,38 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
         }
         MotionEvent event = (MotionEvent) eventObject;
         View stub = (View) stubObject;
+        Object processor = chain.getThisObject();
         ensureMiuiHomeInputArbiterReceiver(stub.getContext());
-        if (event.getActionMasked() == MotionEvent.ACTION_DOWN
+        int action = event.getActionMasked();
+        Long nativeDownTime = miuiHomeNativeInputStreams.get(processor);
+        if (action != MotionEvent.ACTION_DOWN
+                && nativeDownTime != null
+                && nativeDownTime.longValue() == event.getDownTime()) {
+            if (action == MotionEvent.ACTION_UP
+                    || action == MotionEvent.ACTION_CANCEL) {
+                miuiHomeNativeInputStreams.remove(processor);
+            }
+            return chain.proceed();
+        }
+        if (action == MotionEvent.ACTION_DOWN) {
+            miuiHomeNativeInputStreams.remove(processor);
+            miuiHomeLauncherOverviewAtLastDown = miuiOverviewVisible;
+        }
+        if (action == MotionEvent.ACTION_DOWN
+                && shouldPreserveNativeLauncherHomeInput(stub.getContext())) {
+            // Only the idle workspace stays on MiuiHome's native input route. Stateful
+            // launcher surfaces (including an open folder) publish a token and use AOSP.
+            moduleLog(Log.INFO, TAG,
+                    "Preserved native MiuiHome input on launcher Home"
+                            + ", overview=" + miuiOverviewVisible
+                            + ", drawer=" + miuiDrawerVisible
+                            + ", editing=" + miuiLauncherEditing
+                            + ", launcherOpen="
+                            + miuiHomeOpenBreakAnimationActive);
+            miuiHomeNativeInputStreams.put(processor, event.getDownTime());
+            return chain.proceed();
+        }
+        if (action == MotionEvent.ACTION_DOWN
                 && event.getPointerCount() == 1
                 && miuiHomeSystemUiInputArbiterReady
                 && miuiHomeSystemUiInputArbiterGeneration != 0L) {
@@ -2846,12 +2962,23 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 acceptedIntent.putExtra(EXTRA_INPUT_EDGE, edge);
                 acceptedIntent.putExtra(EXTRA_INPUT_ARBITER_GENERATION,
                         miuiHomeSystemUiInputArbiterGeneration);
+                acceptedIntent.putExtra(EXTRA_LAUNCHER_OPEN_ACTIVE,
+                        miuiHomeOpenBreakAnimationActive);
+                acceptedIntent.putExtra(EXTRA_LAUNCHER_OPEN_BREAK_GENERATION,
+                        miuiHomeOpenBreakAnimationActive
+                                ? miuiHomeOpenBreakGeneration : 0L);
+                acceptedIntent.putExtra(EXTRA_LAUNCHER_OVERVIEW_ACTIVE,
+                        miuiHomeLauncherOverviewAtLastDown);
                 MiuiHomeAcceptedInputToken inputIdentity =
                         new MiuiHomeAcceptedInputToken(
                                 eventId, event.getDownTime(),
                                 event.getDeviceId(), event.getSource(),
                                 displayId, edge,
-                                miuiHomeSystemUiInputArbiterGeneration);
+                                miuiHomeSystemUiInputArbiterGeneration,
+                                miuiHomeOpenBreakAnimationActive,
+                                miuiHomeOpenBreakAnimationActive
+                                        ? miuiHomeOpenBreakGeneration : 0L,
+                                miuiHomeLauncherOverviewAtLastDown);
                 miuiHomeAcceptedInputIdentity.set(inputIdentity);
                 sendAuthenticatedMiuiHomeState(stub.getContext(), acceptedIntent);
                 moduleLog(Log.INFO, TAG, "Published MiuiHome accepted input token"
@@ -2870,6 +2997,99 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
         // decisions have accepted the stream. Keep the real Xiaomi input target, but never
         // let its legacy processor create a second BackAnimationAdapter, arrow, or BACK.
         return null;
+    }
+
+    protected boolean shouldPreserveNativeLauncherHomeInput(Context context) {
+        if (context == null || miuiDrawerVisible
+                || miuiLauncherEditing || miuiHomeOpenBreakAnimationActive) {
+            return false;
+        }
+        try {
+            ClassLoader classLoader = context.getClassLoader();
+            Class<?> applicationClass = Class.forName(
+                    MIUI_HOME_APPLICATION, false, classLoader);
+            Method getLauncher = miuiHomeGetLauncherMethod;
+            if (getLauncher == null
+                    || getLauncher.getDeclaringClass().getClassLoader() != classLoader) {
+                getLauncher = applicationClass.getDeclaredMethod("getLauncher");
+                getLauncher.setAccessible(true);
+                miuiHomeGetLauncherMethod = getLauncher;
+            }
+            Object launcher = getLauncher.invoke(null);
+            if (!(launcher instanceof android.app.Activity)) {
+                return false;
+            }
+            boolean launcherOverview = miuiOverviewVisible;
+            try {
+                Class<?> launcherStateClass = Class.forName(
+                        MIUI_HOME_LAUNCHER_STATE, false, classLoader);
+                Object overviewState = miuiHomeOverviewState;
+                if (overviewState == null
+                        || overviewState.getClass() != launcherStateClass) {
+                    overviewState = launcherStateClass.getField("OVERVIEW").get(null);
+                    miuiHomeOverviewState = overviewState;
+                }
+                Method isInState = miuiHomeIsInStateMethod;
+                if (isInState == null
+                        || !isInState.getDeclaringClass().isInstance(launcher)) {
+                    isInState = launcher.getClass().getMethod(
+                            "isInState", launcherStateClass);
+                    isInState.setAccessible(true);
+                    miuiHomeIsInStateMethod = isInState;
+                }
+                launcherOverview |= Boolean.TRUE.equals(
+                        isInState.invoke(launcher, overviewState));
+            } catch (Throwable throwable) {
+                if (!miuiHomeOverviewProbeFailureLogged) {
+                    miuiHomeOverviewProbeFailureLogged = true;
+                    moduleLog(Log.WARN, TAG,
+                            "Failed to inspect direct MiuiHome Overview state; "
+                                    + "using mirrored state",
+                            throwable);
+                }
+            }
+            miuiHomeLauncherOverviewAtLastDown = launcherOverview;
+            if (launcherOverview) {
+                return false;
+            }
+            boolean folderOpen = false;
+            try {
+                Method isFolderOpened = miuiHomeIsFolderOpenedMethod;
+                if (isFolderOpened == null
+                        || !isFolderOpened.getDeclaringClass().isInstance(launcher)) {
+                    isFolderOpened = launcher.getClass().getMethod("isFolderOpened");
+                    isFolderOpened.setAccessible(true);
+                    miuiHomeIsFolderOpenedMethod = isFolderOpened;
+                }
+                folderOpen = Boolean.TRUE.equals(isFolderOpened.invoke(launcher));
+            } catch (Throwable throwable) {
+                if (!miuiHomeFolderProbeFailureLogged) {
+                    miuiHomeFolderProbeFailureLogged = true;
+                    moduleLog(Log.WARN, TAG,
+                            "Failed to inspect MiuiHome folder state; preserving idle-Home proof",
+                            throwable);
+                }
+            }
+            if (folderOpen) {
+                return false;
+            }
+            android.app.Activity activity = (android.app.Activity) launcher;
+            View decor = activity.getWindow() == null
+                    ? null : activity.getWindow().getDecorView();
+            boolean activityFocus = activity.hasWindowFocus();
+            boolean decorFocus = decor != null && decor.hasWindowFocus();
+            boolean decorVisible = decor != null
+                    && decor.getWindowToken() != null
+                    && decor.getVisibility() == View.VISIBLE;
+            boolean preserve = !activity.isFinishing() && !activity.isDestroyed()
+                    && activityFocus && decorFocus && decorVisible;
+            return preserve;
+        } catch (Throwable throwable) {
+            moduleLog(Log.WARN, TAG,
+                    "Failed to identify idle MiuiHome launcher; preserving arbiter path",
+                    throwable);
+            return false;
+        }
     }
 
     protected int readMotionEventId(MotionEvent event) throws Exception {
@@ -3829,6 +4049,7 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
         synchronized (miuiHomeGestureTriggerStubLock) {
             miuiHomeGestureTriggerStubs.clear();
         }
+        miuiHomeNativeInputStreams.clear();
     }
 
     protected int readMiuiHomeGestureDisplayHeight(View stub) {

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeLifecycleRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeLifecycleRuntime.java
@@ -1182,14 +1182,210 @@ abstract class MiuiHomeReturnHomeLifecycleRuntime
                 StandardReturnHomeCommitSignal signal) {
             ReturnHomeLauncherOpenBarrierToken token =
                     pendingLauncherOpenBarrier.get();
-            if (token == null || signal == null
-                    || !matchesReturnHomeSignal(
+            if (token != null && signal != null
+                    && matchesReturnHomeSignal(
                     token.expectedSignal, signal)) {
+                token.finishSignal = signal;
+                token.finishReceived.set(true);
+                completeLauncherOpenBarrier(token);
+            }
+            ReturnHomeWidgetOpenBarrierToken widgetToken =
+                    pendingWidgetOpenBarrier.get();
+            if (widgetToken == null || signal == null
+                    || !matchesReturnHomeSignal(
+                    widgetToken.expectedSignal, signal)) {
                 return;
             }
-            token.finishSignal = signal;
-            token.finishReceived.set(true);
-            completeLauncherOpenBarrier(token);
+            widgetToken.finishSignal = signal;
+            widgetToken.finishReceived.set(true);
+            releaseWidgetOpenBarrier(widgetToken);
+        }
+
+        protected ReturnHomeWidgetOpenBarrierToken prepareWidgetOpenBarrier(
+                Object stateManager, Object[] args) throws Throwable {
+            if (args == null || args.length != 4
+                    || args[3] == null
+                    || Looper.myLooper() != Looper.getMainLooper()) {
+                return null;
+            }
+            Class<?> widgetEventClass = Class.forName(
+                    MIUI_HOME_WIDGET_CLICK_EVENT_INFO, false, classLoader);
+            if (!widgetEventClass.isInstance(args[3])) {
+                return null;
+            }
+
+            ReturnHomeWidgetOpenBarrierToken pending =
+                    pendingWidgetOpenBarrier.get();
+            if (pending != null) {
+                if (pending.stateManager != stateManager
+                        || pending.widgetEvent != args[3]
+                        || pending.args.length != args.length) {
+                    return null;
+                }
+                for (int index = 0; index < args.length; index++) {
+                    if (pending.args[index] != args[index]) {
+                        return null;
+                    }
+                }
+                if (pending.releasing.get()
+                        && pending.resumeEntered.compareAndSet(false, true)) {
+                    return pending;
+                }
+                // Suppress an exact duplicate invocation while the same click is already
+                // waiting for its authenticated Shell cleanup boundary.
+                return pending;
+            }
+
+            ReturnHomeSession session = currentSession;
+            if (session == null || session.finished.get() != 0
+                    || session.cleaned.get() != 0
+                    || !session.nativeHandoffStarted
+                    || !session.nativeAnimationStarted
+                    || !session.nativeContinuationVerified
+                    || session.stateManager != stateManager
+                    || session.nativeWindowElement == null
+                    || session.nativeAnimationIdentity == null
+                    || !"CLOSE_TO_HOME".equals(session.nativeAnimationType)) {
+                return null;
+            }
+            UnifiedNativeAdoptedStandardCommitIdentity standard =
+                    session.unifiedNativeAdoptedStandardCommit;
+            StandardReturnHomeCommitSignal expected = standard == null
+                    ? null : standard.signal;
+            Object currentElement = invokeAnyMethod(
+                    stateManager, "getCurrentWindowElement", new Object[0]);
+            Object currentIdentity = invokeAnyMethod(
+                    session.nativeWindowElement, "getAnimSymbol", new Object[0]);
+            String currentType = readNativeAnimationType(
+                    session.nativeWindowElement);
+            boolean standardOwned = standard != null
+                    && standard.session == session
+                    && standard.generation == session.generation
+                    && standard.windowElement == session.nativeWindowElement
+                    && standard.animationIdentity
+                    == session.nativeAnimationIdentity
+                    && expected != null && !expected.elementBoundaryOnly
+                    && standardSignalMatchesSession(expected, session);
+            if (currentSession != session
+                    || currentElement != session.nativeWindowElement
+                    || currentIdentity != session.nativeAnimationIdentity
+                    || !"CLOSE_TO_HOME".equals(currentType)
+                    || !standardOwned) {
+                moduleLog(Log.WARN, TAG,
+                        "Rejected Xiaomi widget OPEN cleanup barrier"
+                                + ", generation=" + session.generation
+                                + ", sameElement="
+                                + (currentElement == session.nativeWindowElement)
+                                + ", sameIdentity="
+                                + (currentIdentity == session.nativeAnimationIdentity)
+                                + ", type=" + currentType
+                                + ", standardOwned=" + standardOwned);
+                return null;
+            }
+            Method method = stateManager.getClass().getDeclaredMethod(
+                    "onLauncherStartActivity", android.content.Intent.class,
+                    Object.class, View.class, widgetEventClass);
+            method.setAccessible(true);
+            ReturnHomeWidgetOpenBarrierToken token =
+                    new ReturnHomeWidgetOpenBarrierToken(
+                            session, stateManager, method, args.clone(),
+                            args[3], expected);
+            if (!pendingWidgetOpenBarrier.compareAndSet(null, token)) {
+                return null;
+            }
+            moduleLog(Log.INFO, TAG,
+                    "Deferred Xiaomi widget OPEN until Shell cleanup"
+                            + ", generation=" + token.generation
+                            + ", attempt=" + expected.attempt
+                            + ", taskId=" + expected.taskId
+                            + ", transitionDebugId="
+                            + expected.transitionDebugId
+                            + ", widgetEvent="
+                            + shortObject(token.widgetEvent));
+            return token;
+        }
+
+        protected void releaseWidgetOpenBarrier(
+                ReturnHomeWidgetOpenBarrierToken token) {
+            if (Looper.myLooper() != Looper.getMainLooper()) {
+                handler.post(() -> releaseWidgetOpenBarrier(token));
+                return;
+            }
+            boolean valid = pendingWidgetOpenBarrier.get() == token
+                    && (attached || deferredControllerReplacement)
+                    && !token.invalidated.get()
+                    && token.finishReceived.get()
+                    && token.expectedSignal != null
+                    && token.expectedSignal.runnerSession
+                    == token.session.finishedCallback
+                    && matchesReturnHomeSignal(
+                    token.expectedSignal, token.finishSignal);
+            if (!valid || !token.releasing.compareAndSet(false, true)) {
+                if (!valid) {
+                    invalidatePendingWidgetOpenBarrier(
+                            "completionIdentityMismatch");
+                }
+                return;
+            }
+            try {
+                token.method.invoke(token.stateManager, token.args);
+                if (!token.resumeEntered.get()) {
+                    completeWidgetOpenBarrierInvocation(token,
+                            new IllegalStateException(
+                                    "Widget OPEN re-entry was not intercepted"));
+                }
+            } catch (InvocationTargetException exception) {
+                Throwable cause = exception.getCause() == null
+                        ? exception : exception.getCause();
+                completeWidgetOpenBarrierInvocation(token, cause);
+            } catch (Throwable throwable) {
+                completeWidgetOpenBarrierInvocation(token, throwable);
+            }
+        }
+
+        protected void completeWidgetOpenBarrierInvocation(
+                ReturnHomeWidgetOpenBarrierToken token, Throwable failure) {
+            if (token == null || !token.completed.compareAndSet(false, true)) {
+                return;
+            }
+            pendingWidgetOpenBarrier.compareAndSet(token, null);
+            if (failure == null) {
+                moduleLog(Log.INFO, TAG,
+                        "Released Xiaomi widget OPEN after Shell cleanup"
+                                + ", generation=" + token.generation
+                                + ", attempt="
+                                + token.expectedSignal.attempt
+                                + ", taskId="
+                                + token.expectedSignal.taskId
+                                + ", transitionDebugId="
+                                + token.expectedSignal.transitionDebugId);
+            } else {
+                moduleLog(Log.WARN, TAG,
+                        "Failed delayed Xiaomi widget OPEN"
+                                + ", generation=" + token.generation,
+                        failure);
+            }
+            maybeFinishDeferredControllerAfterConfigAck(
+                    "widgetOpenBarrier");
+        }
+
+        protected void invalidatePendingWidgetOpenBarrier(String reason) {
+            ReturnHomeWidgetOpenBarrierToken token =
+                    pendingWidgetOpenBarrier.getAndSet(null);
+            if (token == null || token.completed.get()) {
+                return;
+            }
+            token.invalidated.set(true);
+            token.completed.set(true);
+            moduleLog(Log.INFO, TAG,
+                    "Invalidated Xiaomi widget OPEN cleanup barrier"
+                            + ", generation=" + token.generation
+                            + ", finishReceived="
+                            + token.finishReceived.get()
+                            + ", releasing=" + token.releasing.get()
+                            + ", reason=" + reason);
+            maybeFinishDeferredControllerAfterConfigAck(
+                    "widgetOpenBarrierInvalidated:" + reason);
         }
 
         protected boolean matchesReturnHomeSignal(

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomePreviewRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomePreviewRuntime.java
@@ -53,6 +53,7 @@ abstract class MiuiHomeReturnHomePreviewRuntime
             ReturnHomeSession session = currentSession;
             return (session != null && session.cleaned.get() == 0)
                     || pendingLauncherOpenBarrier.get() != null
+                    || pendingWidgetOpenBarrier.get() != null
                     || !pendingUnifiedInterruptedAnimToConfigs.isEmpty();
         }
 
@@ -84,6 +85,7 @@ abstract class MiuiHomeReturnHomePreviewRuntime
             deathLinked = false;
             invalidatePendingLauncherOpenBarrier(
                     "shellBinderDied", true);
+            invalidatePendingWidgetOpenBarrier("shellBinderDied");
             beginDeferredControllerReplacement("shellBinderDied");
         }
 
@@ -111,6 +113,7 @@ abstract class MiuiHomeReturnHomePreviewRuntime
             attached = false;
             invalidatePendingLauncherOpenBarrier(
                     "detach:" + reason, true);
+            invalidatePendingWidgetOpenBarrier("detach:" + reason);
             invalidatePendingDirectCancel(null, "detach:" + reason, true);
             invalidateElementTransitionContinuity(
                     null, "detach:" + reason, true);
@@ -397,8 +400,6 @@ abstract class MiuiHomeReturnHomePreviewRuntime
                 session.currentRect.set(startBounds);
                 session.startCornerRadius = resolveMiuiWindowCornerRadius(
                         session.previewTarget);
-                session.endCornerRadius =
-                        dp(RETURN_HOME_END_CORNER_RADIUS_DP);
                 session.currentCornerRadius = session.startCornerRadius;
                 Context currentContext = context;
                 session.previewProgressDistancePx = currentContext == null
@@ -691,8 +692,11 @@ abstract class MiuiHomeReturnHomePreviewRuntime
                     ? session.startRect.left + margin
                     : session.startRect.right - margin - width;
             session.currentRect.set(left, top, left + width, top + height);
-            session.currentCornerRadius = lerp(session.startCornerRadius,
-                    session.endCornerRadius, progress);
+            // WindowAnimParams consumes a visual-space radius and compensates it for the
+            // shrinking surface matrix internally. Keep that visual radius stable during
+            // the interactive preview; interpolating toward a smaller dp value makes the
+            // app's physical corners visibly sharpen as it approaches the launcher icon.
+            session.currentCornerRadius = session.startCornerRadius;
             updateNativePreviewBlur(session, rawProgress);
             if (!driveUnifiedNativePreviewFrame(session, false)) {
                 rejectUnavailableNativePreview(

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeStateRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeStateRuntime.java
@@ -52,6 +52,8 @@ abstract class MiuiHomeReturnHomeStateRuntime extends SystemUiHookRuntime {
                 pendingDirectCancel = new AtomicReference<>();
         protected final AtomicReference<ReturnHomeLauncherOpenBarrierToken>
                 pendingLauncherOpenBarrier = new AtomicReference<>();
+        protected final AtomicReference<ReturnHomeWidgetOpenBarrierToken>
+                pendingWidgetOpenBarrier = new AtomicReference<>();
         protected final AtomicReference<ReturnHomeElementLeashReuseToken>
                 pendingElementLeashReuse = new AtomicReference<>();
         protected final AtomicReference<StandardReturnHomeCommitSignal>
@@ -722,6 +724,15 @@ abstract class MiuiHomeReturnHomeStateRuntime extends SystemUiHookRuntime {
         protected abstract void onStandardShellReturnHomeFinished(
                 StandardReturnHomeCommitSignal signal);
 
+        protected abstract ReturnHomeWidgetOpenBarrierToken
+                prepareWidgetOpenBarrier(
+                Object stateManager, Object[] args) throws Throwable;
+
+        protected abstract void completeWidgetOpenBarrierInvocation(
+                ReturnHomeWidgetOpenBarrierToken token, Throwable failure);
+
+        protected abstract void invalidatePendingWidgetOpenBarrier(String reason);
+
         protected abstract boolean matchesReturnHomeSignal(
                 StandardReturnHomeCommitSignal expected,
                 StandardReturnHomeCommitSignal actual);
@@ -1128,6 +1139,35 @@ abstract class MiuiHomeReturnHomeStateRuntime extends SystemUiHookRuntime {
                 this.pendingCommitInterruption =
                         pendingCommitInterruption;
                 this.nativeParallelRoute = nativeParallelRoute;
+            }
+        }
+
+        protected final class ReturnHomeWidgetOpenBarrierToken {
+            final long generation;
+            final ReturnHomeSession session;
+            final Object stateManager;
+            final Method method;
+            final Object[] args;
+            final Object widgetEvent;
+            final StandardReturnHomeCommitSignal expectedSignal;
+            final AtomicBoolean finishReceived = new AtomicBoolean();
+            final AtomicBoolean releasing = new AtomicBoolean();
+            final AtomicBoolean resumeEntered = new AtomicBoolean();
+            final AtomicBoolean completed = new AtomicBoolean();
+            final AtomicBoolean invalidated = new AtomicBoolean();
+            volatile StandardReturnHomeCommitSignal finishSignal;
+
+            ReturnHomeWidgetOpenBarrierToken(
+                    ReturnHomeSession session, Object stateManager,
+                    Method method, Object[] args, Object widgetEvent,
+                    StandardReturnHomeCommitSignal expectedSignal) {
+                this.generation = session.generation;
+                this.session = session;
+                this.stateManager = stateManager;
+                this.method = method;
+                this.args = args;
+                this.widgetEvent = widgetEvent;
+                this.expectedSignal = expectedSignal;
             }
         }
 
@@ -1626,7 +1666,6 @@ abstract class MiuiHomeReturnHomeStateRuntime extends SystemUiHookRuntime {
             float initialTouchY;
             int swipeEdge;
             float startCornerRadius;
-            float endCornerRadius;
             float currentCornerRadius;
             float previewProgressDistancePx;
             float lastInputProgress;

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeUnifiedRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeReturnHomeUnifiedRuntime.java
@@ -814,6 +814,7 @@ abstract class MiuiHomeReturnHomeUnifiedRuntime
             if (!deferredControllerReplacement
                     || currentSession != null
                     || pendingLauncherOpenBarrier.get() != null
+                    || pendingWidgetOpenBarrier.get() != null
                     || !pendingUnifiedInterruptedAnimToConfigs.isEmpty()) {
                 return;
             }

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
@@ -1,16 +1,26 @@
 package dev.codex.miuibackgesturehook.hooks.systemui;
 
+import dev.codex.miuibackgesturehook.PredictiveBackPreferences;
+
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.SuppressLint;
+import android.app.WallpaperManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Insets;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
@@ -21,6 +31,7 @@ import android.util.Log;
 import android.view.Display;
 import android.view.HapticFeedbackConstants;
 import android.view.InsetsFrameProvider;
+import android.view.Surface;
 import android.view.SurfaceControl;
 import android.view.View;
 import android.view.WindowInsets;
@@ -191,8 +202,14 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
             animators[index] = (Animator) animator;
         }
         Object originalSizeObject = ((Map<?, ?>) animationSizeObject).get(token);
-        int originalSize = originalSizeObject instanceof Number
+        int recordedSize = originalSizeObject instanceof Number
                 ? ((Number) originalSizeObject).intValue() : 0;
+        // HyperOS 3 keeps mAnimationSize at zero for the normal two-animator
+        // Activity OPEN path even though mAnimations already contains the complete set.
+        // Treat the atomically captured list as the baseline on that implementation;
+        // the executor-side equality, canReverse(), and isRunning() checks below still
+        // reject a partial, stale, or non-interruptible transition.
+        int originalSize = recordedSize > 0 ? recordedSize : animators.length;
         if (animators.length == 0) {
             return;
         }
@@ -1644,7 +1661,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
             hookFreeformCrossActivityScrimCreation();
             hookCrossActivitySlideAnimation(classLoader,
                     true, true, true, true, true, true);
-            hookCrossTaskBackground(classLoader);
+            hookPredictiveBackBackground(classLoader);
             moduleLog(Log.INFO, TAG, "Hooked Shell BackAnimationController AOSP path");
         } catch (Throwable throwable) {
             moduleLog(Log.ERROR, TAG, "Failed to hook Shell back animation", throwable);
@@ -2379,42 +2396,65 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
         }
     }
 
-    protected void hookCrossTaskBackground(ClassLoader classLoader) {
+    protected void hookPredictiveBackBackground(ClassLoader classLoader) {
         try {
             Class<?> backgroundClass = Class.forName(
                     BACK_ANIMATION_BACKGROUND, false, classLoader);
+            boolean ensureHooked = false;
+            boolean removeHooked = false;
             for (Method method : backgroundClass.getDeclaredMethods()) {
                 if ("ensureBackground".equals(method.getName())
-                        && method.getParameterCount() == 6) {
+                        && (method.getParameterCount() == 4
+                        || method.getParameterCount() == 6)) {
                     method.setAccessible(true);
                     recordHookHandle(hook(method)
-                            .setId("systemui_cross_task_background")
-                            .intercept(this::tintCrossTaskBackground));
-                    moduleLog(Log.INFO, TAG, "Hooked cross-task background tint");
-                    return;
+                            .setId("systemui_predictive_background_ensure_"
+                                    + method.getParameterCount())
+                            .intercept(this::customizePredictiveBackBackground));
+                    ensureHooked = true;
+                } else if ("removeBackground".equals(method.getName())
+                        && method.getParameterCount() == 1) {
+                    method.setAccessible(true);
+                    recordHookHandle(hook(method)
+                            .setId("systemui_predictive_background_remove")
+                            .intercept(this::removePredictiveBackBackground));
+                    removeHooked = true;
                 }
             }
-            moduleLog(Log.WARN, TAG, "BackAnimationBackground.ensureBackground not found");
+            if (!ensureHooked) {
+                moduleLog(Log.WARN, TAG,
+                        "BackAnimationBackground.ensureBackground not found");
+            }
+            if (!removeHooked) {
+                moduleLog(Log.WARN, TAG,
+                        "BackAnimationBackground.removeBackground not found");
+            }
+            moduleLog(Log.INFO, TAG,
+                    "Hooked shared predictive-back backdrop lifecycle"
+                            + ", ensure=" + ensureHooked
+                            + ", remove=" + removeHooked);
         } catch (Throwable throwable) {
-            moduleLog(Log.ERROR, TAG, "Failed to hook cross-task background", throwable);
+            moduleLog(Log.ERROR, TAG,
+                    "Failed to hook predictive-back backdrop lifecycle", throwable);
         }
     }
 
     /**
-     * With the slide preference on, repaints the native cross-task color-layer
-     * background pure black. ensureBackground(bounds, color, transaction, ...) creates
-     * the color layer and writes the color into the caller's pending transaction; when
-     * the color is cross-task's hard-coded tint, overwrite it on that same transaction
-     * before it is applied. Cross-activity passes its task color and is left alone.
+     * Customizes the native predictive-back color layer in the caller's pending transaction.
+     * HyperOS slide mode keeps its established black tint. AOSP mode may either retain
+     * the system fill, paint it black, or make only that fill layer transparent so the
+     * real lower target (including Home's static/live wallpaper) remains visible. No
+     * wallpaper bitmap is copied or retained on this animation hot path.
      */
-    protected Object tintCrossTaskBackground(XposedInterface.Chain chain)
+    protected Object customizePredictiveBackBackground(XposedInterface.Chain chain)
             throws Throwable {
         Object colorArg = chain.getArg(1);
         int color = colorArg instanceof Number ? ((Number) colorArg).intValue() : 0;
         Object result = chain.proceed();
         try {
-            if (color != CROSS_TASK_BACKGROUND_COLOR
-                    || !isHyperOsSlideAnimationEnabled()) {
+            int backgroundMode = getAospBackgroundMode();
+            if (backgroundMode
+                    == PredictiveBackPreferences.AOSP_BACKGROUND_SYSTEM) {
                 return result;
             }
             Object surface = readFieldOrNull(
@@ -2423,28 +2463,91 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
             if (surface instanceof SurfaceControl
                     && ((SurfaceControl) surface).isValid()
                     && transaction instanceof SurfaceControl.Transaction) {
-                invokeMethod(transaction, "setColor",
+                SurfaceControl background = (SurfaceControl) surface;
+                SurfaceControl.Transaction surfaceTransaction =
+                        (SurfaceControl.Transaction) transaction;
+                surfaceTransaction.setAlpha(background, 1.0f);
+                invokeMethod(surfaceTransaction, "setColor",
                         new Class<?>[]{SurfaceControl.class, float[].class},
-                        new Object[]{surface, new float[]{0.0f, 0.0f, 0.0f}});
-                moduleLog(Log.INFO, TAG, "Repainted cross-task background black");
+                        new Object[]{background, new float[]{0.0f, 0.0f, 0.0f}});
+                AospBackgroundMaskState previous = aospBackgroundMaskState;
+                if (previous != null
+                        && previous.animation == chain.getThisObject()
+                        && previous.background == background
+                        && previous.mode == backgroundMode) {
+                    return result;
+                }
+                if (previous != null) {
+                    releaseAospWallpaperLayer(previous.wallpaperBlurLayer);
+                    releaseAospWallpaperLayer(previous.wallpaperLayer);
+                    aospBackgroundMaskState = null;
+                }
+                SurfaceControl wallpaperLayer = null;
+                SurfaceControl wallpaperBlurLayer = null;
+                if (backgroundMode
+                        == PredictiveBackPreferences.AOSP_BACKGROUND_WALLPAPER) {
+                    Rect bounds = chain.getArg(0) instanceof Rect
+                            ? (Rect) chain.getArg(0) : null;
+                    AospWallpaperBackdrop backdrop =
+                            createAospWallpaperBackdrop(
+                                    chain.getThisObject(), bounds,
+                                    background, surfaceTransaction);
+                    wallpaperLayer = backdrop.wallpaperLayer;
+                    wallpaperBlurLayer = backdrop.blurLayer;
+                    surfaceTransaction.setLayer(wallpaperLayer, 0)
+                            .setAlpha(wallpaperLayer, 1.0f);
+                }
+                aospBackgroundMaskState = new AospBackgroundMaskState(
+                        chain.getThisObject(), backgroundMode,
+                        surfaceTransaction, null, null, background,
+                        wallpaperLayer, wallpaperBlurLayer, false);
+                moduleLog(Log.INFO, TAG,
+                        "Applied shared predictive-back backdrop"
+                                + ", mode=" + backgroundMode
+                                + ", originalColor=0x"
+                                + Integer.toHexString(color)
+                                + ", wallpaperLayer="
+                                + (wallpaperLayer != null)
+                                + ", blurLayer="
+                                + (wallpaperBlurLayer != null));
             }
         } catch (Throwable throwable) {
-            moduleLog(Log.WARN, TAG, "Failed to tint cross-task background black", throwable);
+            moduleLog(Log.WARN, TAG,
+                    "Failed to customize predictive-back backdrop", throwable);
         }
         return result;
+    }
+
+    protected Object removePredictiveBackBackground(XposedInterface.Chain chain)
+            throws Throwable {
+        AospBackgroundMaskState state = aospBackgroundMaskState;
+        if (state != null && state.animation == chain.getThisObject()) {
+            aospBackgroundMaskState = null;
+            releaseAospWallpaperLayer(state.wallpaperBlurLayer);
+            releaseAospWallpaperLayer(state.wallpaperLayer);
+        }
+        return chain.proceed();
     }
 
     // finishAnimation() is the animation's natural end; clear the session flag so a
     // later gesture re-arms cleanly. The original always runs.
     protected Object onCrossActivitySlideFinish(XposedInterface.Chain chain)
             throws Throwable {
+        Object animation = chain.getThisObject();
         miuixSlideAnimActive = false;
         freeformColorRootCandidate.set(null);
         FreeformColorRootAdoption adoption = freeformColorRootAdoption;
-        if (adoption != null && adoption.animation == chain.getThisObject()) {
+        if (adoption != null && adoption.animation == animation) {
             freeformColorRootAdoption = null;
         }
-        return chain.proceed();
+        Object result = chain.proceed();
+        AospBackgroundMaskState maskState = aospBackgroundMaskState;
+        if (maskState != null && maskState.animation == animation) {
+            aospBackgroundMaskState = null;
+            releaseAospWallpaperLayer(maskState.wallpaperBlurLayer);
+            releaseAospWallpaperLayer(maskState.wallpaperLayer);
+        }
+        return result;
     }
 
     /**
@@ -2511,6 +2614,50 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
     }
 
     protected volatile boolean miuixSlideAnimActive;
+    protected volatile AospBackgroundMaskState aospBackgroundMaskState;
+
+    protected static final class AospBackgroundMaskState {
+        final Object animation;
+        final int mode;
+        final SurfaceControl.Transaction transaction;
+        final SurfaceControl closingLeash;
+        final SurfaceControl enteringLeash;
+        final SurfaceControl background;
+        final SurfaceControl wallpaperLayer;
+        final SurfaceControl wallpaperBlurLayer;
+        final boolean failed;
+
+        AospBackgroundMaskState(
+                Object animation, int mode,
+                SurfaceControl.Transaction transaction,
+                SurfaceControl closingLeash, SurfaceControl enteringLeash,
+                SurfaceControl background, SurfaceControl wallpaperLayer,
+                SurfaceControl wallpaperBlurLayer,
+                boolean failed) {
+            this.animation = animation;
+            this.mode = mode;
+            this.transaction = transaction;
+            this.closingLeash = closingLeash;
+            this.enteringLeash = enteringLeash;
+            this.background = background;
+            this.wallpaperLayer = wallpaperLayer;
+            this.wallpaperBlurLayer = wallpaperBlurLayer;
+            this.failed = failed;
+        }
+    }
+    protected static final class AospWallpaperBackdrop {
+        final SurfaceControl wallpaperLayer;
+        final SurfaceControl blurLayer;
+
+        AospWallpaperBackdrop(
+                SurfaceControl wallpaperLayer, SurfaceControl blurLayer) {
+            this.wallpaperLayer = wallpaperLayer;
+            this.blurLayer = blurLayer;
+        }
+    }
+    protected final Object aospWallpaperSnapshotLock = new Object();
+    protected volatile Bitmap aospWallpaperSnapshot;
+    protected volatile int aospWallpaperSnapshotId = Integer.MIN_VALUE;
     protected final RectF miuixSlideCommitClosing = new RectF();
     protected final RectF miuixSlideCommitEntering = new RectF();
     protected boolean miuixSlideCommitPoseCaptured;
@@ -2781,6 +2928,174 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
                             candidate.closingTarget, "taskId", -1));
         }
         return result;
+    }
+
+    protected AospWallpaperBackdrop createAospWallpaperBackdrop(
+            Object backgroundOwner, Rect frame, SurfaceControl background,
+            SurfaceControl.Transaction transaction) throws Exception {
+        Object ownerContext = readFieldOrNull(backgroundOwner, "mContext");
+        Context context = ownerContext instanceof Context
+                ? ((Context) ownerContext).getApplicationContext()
+                : miuiOverviewReceiverContext;
+        if (context == null || frame == null || frame.isEmpty()) {
+            throw new IllegalStateException("wallpaper context or animation bounds unavailable");
+        }
+        int width = frame.width();
+        int height = frame.height();
+        Bitmap snapshot = obtainAospWallpaperSnapshot(context);
+        SurfaceControl layer = new SurfaceControl.Builder()
+                .setName("MiuiBackGestureHook-AospWallpaper")
+                .setParent(background)
+                .setBufferSize(width, height)
+                .setFormat(PixelFormat.RGBA_8888)
+                .setOpaque(true)
+                .setHidden(false)
+                .build();
+        boolean drawn = false;
+        Surface surface = null;
+        Canvas canvas = null;
+        try {
+            surface = new Surface(layer);
+            canvas = surface.lockCanvas(null);
+            canvas.drawColor(Color.BLACK);
+            float scale = Math.max(
+                    width / (float) snapshot.getWidth(),
+                    height / (float) snapshot.getHeight());
+            float drawnWidth = snapshot.getWidth() * scale;
+            float drawnHeight = snapshot.getHeight() * scale;
+            RectF destination = new RectF(
+                    (width - drawnWidth) * 0.5f,
+                    (height - drawnHeight) * 0.5f,
+                    (width + drawnWidth) * 0.5f,
+                    (height + drawnHeight) * 0.5f);
+            Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
+            canvas.drawBitmap(snapshot, null, destination, paint);
+            surface.unlockCanvasAndPost(canvas);
+            canvas = null;
+            drawn = true;
+            SurfaceControl blurLayer = aospWallpaperBlurEnabled
+                    ? createAospWallpaperBlurLayer(
+                    background, width, height, transaction)
+                    : null;
+            return new AospWallpaperBackdrop(layer, blurLayer);
+        } finally {
+            if (surface != null) {
+                if (canvas != null) {
+                    try {
+                        surface.unlockCanvasAndPost(canvas);
+                    } catch (Throwable ignored) {
+                    }
+                }
+                surface.release();
+            }
+            if (!drawn) {
+                layer.release();
+            }
+        }
+    }
+
+    protected SurfaceControl createAospWallpaperBlurLayer(
+            SurfaceControl background, int width, int height,
+            SurfaceControl.Transaction transaction) {
+        SurfaceControl layer = null;
+        Surface surface = null;
+        Canvas canvas = null;
+        boolean prepared = false;
+        try {
+            layer = new SurfaceControl.Builder()
+                    .setName("MiuiBackGestureHook-AospWallpaperBlur")
+                    .setParent(background)
+                    .setBufferSize(width, height)
+                    .setFormat(PixelFormat.RGBA_8888)
+                    .setOpaque(false)
+                    .setHidden(false)
+                    .build();
+            surface = new Surface(layer);
+            canvas = surface.lockCanvas(null);
+            canvas.drawColor(Color.TRANSPARENT,
+                    android.graphics.PorterDuff.Mode.CLEAR);
+            surface.unlockCanvasAndPost(canvas);
+            canvas = null;
+            invokeMethod(transaction, "setBackgroundBlurRadius",
+                    new Class<?>[]{SurfaceControl.class, int.class},
+                    new Object[]{layer, Integer.valueOf(100)});
+            transaction.setLayer(layer, 1).setAlpha(layer, 1.0f);
+            prepared = true;
+            moduleLog(Log.INFO, TAG,
+                    "Enabled experimental HyperOS compositor wallpaper blur"
+                            + ", radius=100");
+            return layer;
+        } catch (Throwable throwable) {
+            moduleLog(Log.WARN, TAG,
+                    "HyperOS compositor wallpaper blur unavailable;"
+                            + " using clear wallpaper",
+                    throwable);
+            return null;
+        } finally {
+            if (surface != null) {
+                if (canvas != null) {
+                    try {
+                        surface.unlockCanvasAndPost(canvas);
+                    } catch (Throwable ignored) {
+                    }
+                }
+                surface.release();
+            }
+            if (!prepared && layer != null) {
+                layer.release();
+            }
+        }
+    }
+
+    protected Bitmap obtainAospWallpaperSnapshot(Context context) {
+        WallpaperManager wallpaperManager = WallpaperManager.getInstance(context);
+        int wallpaperId = wallpaperManager.getWallpaperId(WallpaperManager.FLAG_SYSTEM);
+        Bitmap cached = aospWallpaperSnapshot;
+        if (cached != null && !cached.isRecycled()
+                && aospWallpaperSnapshotId == wallpaperId) {
+            return cached;
+        }
+        synchronized (aospWallpaperSnapshotLock) {
+            cached = aospWallpaperSnapshot;
+            if (cached != null && !cached.isRecycled()
+                    && aospWallpaperSnapshotId == wallpaperId) {
+                return cached;
+            }
+            Drawable drawable = wallpaperManager.getDrawable(WallpaperManager.FLAG_SYSTEM);
+            if (!(drawable instanceof BitmapDrawable)) {
+                throw new IllegalStateException("system wallpaper snapshot is not bitmap-backed");
+            }
+            Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+            if (bitmap == null || bitmap.isRecycled()
+                    || bitmap.getWidth() <= 0 || bitmap.getHeight() <= 0) {
+                throw new IllegalStateException("system wallpaper snapshot is unavailable");
+            }
+            aospWallpaperSnapshot = bitmap;
+            aospWallpaperSnapshotId = wallpaperId;
+            return bitmap;
+        }
+    }
+
+    protected void releaseAospWallpaperLayer(SurfaceControl wallpaperLayer) {
+        if (wallpaperLayer == null) {
+            return;
+        }
+        try {
+            if (wallpaperLayer.isValid()) {
+                try (SurfaceControl.Transaction transaction =
+                             new SurfaceControl.Transaction()) {
+                    invokeMethod(transaction, "remove",
+                            new Class<?>[]{SurfaceControl.class},
+                            new Object[]{wallpaperLayer});
+                    transaction.apply();
+                }
+            }
+        } catch (Throwable throwable) {
+            moduleLog(Log.WARN, TAG,
+                    "Failed to remove AOSP wallpaper backdrop layer", throwable);
+        } finally {
+            wallpaperLayer.release();
+        }
     }
 
     protected void applyAdoptedFreeformTargetGeometry(
@@ -4919,7 +5234,11 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
                 intent.getIntExtra(EXTRA_INPUT_DEVICE_ID, Integer.MIN_VALUE),
                 intent.getIntExtra(EXTRA_INPUT_SOURCE, 0),
                 intent.getIntExtra(EXTRA_INPUT_DISPLAY_ID, Integer.MIN_VALUE),
-                intent.getIntExtra(EXTRA_INPUT_EDGE, -1), generation);
+                intent.getIntExtra(EXTRA_INPUT_EDGE, -1), generation,
+                intent.getBooleanExtra(EXTRA_LAUNCHER_OPEN_ACTIVE, false),
+                intent.getLongExtra(
+                        EXTRA_LAUNCHER_OPEN_BREAK_GENERATION, 0L),
+                intent.getBooleanExtra(EXTRA_LAUNCHER_OVERVIEW_ACTIVE, false));
         if (token.downTime == Long.MIN_VALUE
                 || token.deviceId == Integer.MIN_VALUE
                 || token.displayId == Integer.MIN_VALUE
@@ -4931,6 +5250,15 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
                     + ", displayId=" + token.displayId
                     + ", edge=" + token.edge);
             return;
+        }
+        if (token.launcherOpenActive
+                && token.launcherOpenGeneration != 0L
+                && token.launcherOpenGeneration
+                >= miuiLauncherOpenBreakGeneration) {
+            // The accepted-DOWN broadcast is emitted synchronously from MiuiHome's processor.
+            // It can beat the separate settled-state broadcast at the start of launcher OPEN.
+            miuiLauncherOpenActive = true;
+            miuiLauncherOpenBreakGeneration = token.launcherOpenGeneration;
         }
         acceptedInputToken.set(token);
         boolean consumed = new ArrayList<>(nativeInputMonitors.values()).stream()
@@ -4947,6 +5275,9 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
                 + ", downTime=" + token.downTime
                 + ", displayId=" + token.displayId
                 + ", edge=" + token.edge
+                + ", launcherOpen=" + token.launcherOpenActive
+                + ", launcherOpenGeneration="
+                + token.launcherOpenGeneration
                 + ", matchedPendingDown=" + consumed
                 + ", generation=" + generation);
     }

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiInputRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiInputRuntime.java
@@ -90,9 +90,11 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
 
     @Override
     protected boolean isHyperOsSlideAnimationEnabled() {
-        return readHyperOsBooleanPreference(
-                PredictiveBackPreferences.KEY_HYPEROS_SLIDE_ANIMATION,
-                PredictiveBackPreferences.DEFAULT_HYPEROS_SLIDE_ANIMATION);
+        return cachedHyperOsSlideAnimationEnabled;
+    }
+
+    protected int getAospBackgroundMode() {
+        return aospBackgroundMode;
     }
 
     protected boolean readHyperOsBooleanPreference(String key, boolean defaultValue) {
@@ -217,6 +219,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
         protected boolean launcherShadeCandidate;
         protected boolean launcherDrawerCandidate;
         protected boolean launcherEditingCandidate;
+        protected boolean launcherHomeTokenRequiredCandidate;
         protected boolean miuiHomeInputAccepted;
         protected boolean pilfered;
         protected boolean waitingForTransientBarsAtDown;
@@ -329,7 +332,8 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
         protected boolean onNativeDown(MotionEvent event) {
             resetCandidate();
             int edge = edgeForDown(event);
-            if (edge < 0 || !canStartBackGesture(event, edge)) {
+            boolean eligible = edge >= 0 && canStartBackGesture(event, edge);
+            if (!eligible) {
                 return false;
             }
             gestureCandidate = true;
@@ -373,13 +377,26 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                 return false;
             }
             if (!miuiHomeInputAccepted) {
-                replacePendingMotionEvent(event);
                 MiuiHomeAcceptedInputToken token = acceptedInputToken.get();
                 if (token != null && matchesMiuiHomeInput(token)
                         && acceptedInputToken.compareAndSet(token, null)) {
                     acceptMiuiHomeInput(token);
                 }
-                return pilfered;
+                if (!gestureCandidate) {
+                    return false;
+                }
+                if (miuiHomeInputAccepted) {
+                    // The current MOVE is newer than any replayed event and can be handled
+                    // directly below.
+                } else if (launcherHomeTokenRequiredCandidate) {
+                    // Idle Launcher never emits a token. Avoid allocating/copying one
+                    // MotionEvent per frame while this spy waits to distinguish an open
+                    // folder from the scrollable desktop.
+                    return false;
+                } else {
+                    replacePendingMotionEvent(event);
+                    return false;
+                }
             }
             if (nativeTransientBarsClaimedGesture()) {
                 return yieldToNativeTransientBars(event, "move");
@@ -433,6 +450,15 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
         boolean acceptMiuiHomeInput(MiuiHomeAcceptedInputToken token) {
             if (!matchesMiuiHomeInput(token)) {
                 return false;
+            }
+            if (token.launcherOpenActive
+                    && token.launcherOpenGeneration != 0L) {
+                launcherOpenBreakCandidate = true;
+                launcherOpenBreakGenerationCandidate =
+                        token.launcherOpenGeneration;
+            }
+            if (token.launcherOverviewActive) {
+                driver.acceptLauncherOverviewForCurrentDown();
             }
             miuiHomeInputAccepted = true;
             MotionEvent down = pendingDownEvent;
@@ -740,10 +766,11 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                     && !miuiOverviewVisible
                     && !launcherOpenBreak
                     && !launcherDrawer;
-            if (launcherHome && !miuiOverviewVisible
+            boolean launcherHomeTokenRequired = launcherHome && !miuiOverviewVisible
                     && !launcherOpenBreak && !launcherShade
-                    && !launcherDrawer && !launcherEditing) {
-                moduleLog(Log.INFO, TAG, "Ignored native back on launcher Home"
+                    && !launcherDrawer && !launcherEditing;
+            if (launcherHomeTokenRequired) {
+                moduleLog(Log.INFO, TAG, "Awaiting MiuiHome accepted token on launcher Home"
                         + ", topActivity=" + topActivity.flattenToShortString()
                         + ", overviewVisible=false"
                         + ", launcherShade=false"
@@ -757,7 +784,6 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                         + launcherOpenBreakCommandsInFlight.get()
                         + ", generation=" + miuiLauncherOpenBreakGeneration
                         + ", displayId=" + displayId);
-                return false;
             }
             if (launcherPackage && !launcherHome) {
                 moduleLog(Log.INFO, TAG, "Accepted non-Home MiuiHome activity as a normal back target"
@@ -853,6 +879,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             launcherShadeCandidate = launcherShade;
             launcherDrawerCandidate = launcherDrawer;
             launcherEditingCandidate = launcherEditing;
+            launcherHomeTokenRequiredCandidate = launcherHomeTokenRequired;
             // Geometry, attachment, touchability, and redirect acceptance are proved later
             // by the matching token emitted only from MiuiHome's accepted processor boundary.
             return true;
@@ -1178,6 +1205,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             launcherShadeCandidate = false;
             launcherDrawerCandidate = false;
             launcherEditingCandidate = false;
+            launcherHomeTokenRequiredCandidate = false;
             miuiHomeInputAccepted = false;
             pilfered = false;
             waitingForTransientBarsAtDown = false;
@@ -1283,6 +1311,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             final AtomicReference<MiuiHomeAcceptedInputToken> inputIdentity;
             final AtomicBoolean releaseQueued = new AtomicBoolean();
             final AtomicBoolean moveFailed = new AtomicBoolean();
+            final AtomicBoolean legacyFallbackRequested = new AtomicBoolean();
             final AtomicBoolean awaitingStockCleanup = new AtomicBoolean();
             final AtomicBoolean completionConsumed = new AtomicBoolean();
 
@@ -1321,6 +1350,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
         protected boolean shellGestureStartDeferred;
         protected volatile boolean gestureSuppressed;
         protected boolean legacyInterruptGesture;
+        protected boolean legacyBusyFallbackGesture;
         protected boolean aospNullNavigationGesture;
         protected Object legacyRunningOpenInfo;
         protected boolean launcherOpenBreakGesture;
@@ -1329,6 +1359,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
         protected long pendingLauncherOpenBreakGeneration;
         protected long pendingLauncherOpenBreakAttemptId;
         protected boolean launcherOverviewGesture;
+        protected boolean acceptedLauncherOverviewForCurrentDown;
         protected boolean launcherShadeGesture;
         protected boolean launcherDrawerGesture;
         protected boolean launcherEditingGesture;
@@ -1518,14 +1549,16 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             if (!gestureActive || gestureSuppressed) {
                 return false;
             }
-            if (!shellGestureStartDeferred
-                    || findReversibleRunningOpenTransition() != null) {
+            if (legacyBusyFallbackGesture
+                    || !shellGestureStartDeferred
+                    || findRunningOpenTransitionForLegacyBack() != null) {
                 return true;
             }
             ShellOwner owner = gestureOwner;
             if (!isShellOwnerCurrent(owner)
                     || !prepareShellSessionSlotForStart()) {
-                return false;
+                return armLegacyBusyFallback(
+                        "Shell owner/session unavailable before pilfer");
             }
             AtomicBoolean ready = new AtomicBoolean();
             AtomicReference<String> state = new AtomicReference<>("not-run");
@@ -1540,12 +1573,101 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                 }
             }, "prePilferReadiness");
             if (!completed || !ready.get()) {
-                moduleLog(Log.INFO, TAG,
-                        "Left accepted gesture unpilfered while Shell is busy"
-                                + ", state=" + state.get());
-                return false;
+                return armLegacyBusyFallback(
+                        "Shell busy before pilfer, state=" + state.get());
             }
             return true;
+        }
+
+        void acceptLauncherOverviewForCurrentDown() {
+            acceptedLauncherOverviewForCurrentDown = true;
+        }
+
+        /**
+         * Keep a newly accepted physical gesture usable while an older predictive-back
+         * animation, a focus-taking child window, or a stale vendor callback still owns
+         * Shell's single navigation slot. The gesture remains authenticated by MiuiHome,
+         * uses the native BackPanel decision, and emits one ordinary BACK only on commit.
+         */
+        protected boolean armLegacyBusyFallback(String reason) {
+            if (!gestureActive || gestureSuppressed
+                    || launcherOpenBreakGesture
+                    || launcherOverviewGesture || launcherShadeGesture
+                    || launcherDrawerGesture || launcherEditingGesture
+                    || gestureOwner == null) {
+                return false;
+            }
+            shellGestureStartDeferred = false;
+            shellGestureStarted = false;
+            legacyBusyFallbackGesture = true;
+            aospNullNavigationGesture = false;
+            moduleLog(Log.INFO, TAG,
+                    "Armed continuous legacy BACK fallback"
+                            + ", reason=" + reason
+                            + ", controller="
+                            + shortObject(gestureOwner.controller)
+                            + ", inputEpoch=" + gestureOwner.inputEpoch
+                            + ", edge=" + activeEdge);
+            return true;
+        }
+
+        protected boolean promoteShellResetToLegacyFallback(
+                ShellGestureSession session, String reason) {
+            if (session == null
+                    || !session.legacyFallbackRequested.get()
+                    || legacyBusyFallbackGesture) {
+                return legacyBusyFallbackGesture;
+            }
+            boolean promoted = armLegacyBusyFallback(reason
+                    + ", shellSessionId=" + session.id);
+            if (promoted) {
+                moduleLog(Log.INFO, TAG,
+                        "Preserved active BackPanel after Shell focus reset"
+                                + ", shellSessionId=" + session.id
+                                + ", edge=" + activeEdge);
+            }
+            return promoted;
+        }
+
+        protected void detectShellResetBeforeRelease(ShellGestureSession session) {
+            if (session == null || session.legacyFallbackRequested.get()
+                    || session.completionConsumed.get()) {
+                return;
+            }
+            executeShellBlocking(session.executor, () -> {
+                Object tracker = null;
+                try {
+                    tracker = invokeAnyMethod(session.controller,
+                            "getActiveTracker", new Object[0]);
+                    Object navigation = readField(session.controller,
+                            "mBackNavigationInfo");
+                    boolean receivedNull = Boolean.TRUE.equals(readField(
+                            session.controller, "mReceivedNullNavigationInfo"));
+                    boolean identityChanged = tracker != session.tracker
+                            || navigation != session.navigation
+                            || (session.navigation == null
+                            && receivedNull != session.receivedNullNavigation);
+                    if (!identityChanged) {
+                        return;
+                    }
+                    session.moveFailed.set(true);
+                    session.legacyFallbackRequested.set(true);
+                    moduleLog(Log.WARN, TAG,
+                            "Detected Shell focus reset at physical release"
+                                    + ", shellSessionId=" + session.id
+                                    + ", tracker=" + shortObject(tracker)
+                                    + ", navigation="
+                                    + shortObject(navigation));
+                    if (session.releaseQueued.compareAndSet(false, true)) {
+                        cancelFailedShellRelease(session, tracker);
+                    }
+                } catch (Throwable throwable) {
+                    moduleLog(Log.WARN, TAG,
+                            "Failed to verify Shell identity before release"
+                                    + ", shellSessionId=" + session.id,
+                            throwable);
+                }
+            }, "verifyIdentityBeforePhysicalRelease");
         }
 
         protected boolean onDown(MotionEvent event, int edge,
@@ -1560,6 +1682,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             shellGestureStartDeferred = false;
             gestureSuppressed = false;
             legacyInterruptGesture = false;
+            legacyBusyFallbackGesture = false;
             aospNullNavigationGesture = false;
             legacyRunningOpenInfo = null;
             launcherOpenBreakGesture = launcherOpenBreakCandidate;
@@ -1567,7 +1690,9 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                     ? launcherOpenBreakGenerationCandidate : 0L;
             launcherOpenBreakAttemptId = launcherOpenBreakCandidate
                     ? launcherOpenBreakAttemptIds.incrementAndGet() : 0L;
-            launcherOverviewGesture = miuiOverviewVisible && !launcherShadeCandidate;
+            launcherOverviewGesture = (acceptedLauncherOverviewForCurrentDown
+                    || miuiOverviewVisible) && !launcherShadeCandidate;
+            acceptedLauncherOverviewForCurrentDown = false;
             launcherShadeGesture = launcherShadeCandidate;
             launcherDrawerGesture = launcherDrawerCandidate;
             launcherEditingGesture = launcherEditingCandidate;
@@ -1682,16 +1807,22 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                     : downX - lastX;
             boolean intentQualified = hasXiaomiBackIntent(
                     distance, lastY - downY, dp(PILFER_THRESHOLD_DP));
+            promoteShellResetToLegacyFallback(
+                    activeShellSession, "Shell identity changed during active gesture");
             if (shellGestureStartDeferred && intentQualified) {
                 shellGestureStartDeferred = false;
                 if (!startShellGesture()) {
-                    cancelLocalGesture(event,
-                            "BackNavigationInfo unavailable at intent threshold");
-                    return false;
+                    if (!armLegacyBusyFallback(
+                            "Shell rejected navigation at intent threshold")) {
+                        cancelLocalGesture(event,
+                                "BackNavigationInfo unavailable at intent threshold");
+                        return false;
+                    }
                 }
                 moduleLog(Log.INFO, TAG, "Started in-app back path at 8dp intent threshold"
                         + ", shellGestureStarted=" + shellGestureStarted
                         + ", legacyInterrupt=" + legacyInterruptGesture
+                        + ", legacyBusyFallback=" + legacyBusyFallbackGesture
                         + ", aospNullNavigation=" + aospNullNavigationGesture
                         + ", edge=" + activeEdge
                         + ", x=" + event.getRawX()
@@ -1702,12 +1833,17 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                 crossedNow = crossIntentThreshold(distance);
             }
             if (!shellGestureStartDeferred
-                    && !legacyInterruptGesture && !launcherOpenBreakGesture) {
+                    && !legacyInterruptGesture && !legacyBusyFallbackGesture
+                    && !launcherOpenBreakGesture) {
                 ShellGestureSession session = activeShellSession;
                 if (session == null || !queueShellMove(session,
                         event.getRawX(), event.getRawY(), distance,
                         crossedNow, thresholdCrossed
                                 && !aospNullNavigationGesture)) {
+                    if (promoteShellResetToLegacyFallback(
+                            session, "Shell rejected MOVE after focus reset")) {
+                        return true;
+                    }
                     cancelLocalGesture(event,
                             "failed to queue Shell-owner MOVE");
                     return false;
@@ -1838,6 +1974,9 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             if (!gestureActive) {
                 return false;
             }
+            detectShellResetBeforeRelease(activeShellSession);
+            promoteShellResetToLegacyFallback(
+                    activeShellSession, "Shell identity changed before release");
             if (gestureSuppressed) {
                 dispatchToEdgePlugin(event, activeEdge);
                 clearControllerTriggerAfterVisualOnlyGesture();
@@ -1848,8 +1987,8 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             if (launcherOpenBreakGesture) {
                 return finishLauncherOpenBreakGesture(event, allowTrigger);
             }
-            if (legacyInterruptGesture) {
-                return finishLegacyInterruptGesture(event, allowTrigger);
+            if (legacyInterruptGesture || legacyBusyFallbackGesture) {
+                return finishLegacyBackGesture(event, allowTrigger);
             }
             if (recentsVisualOnlyGesture) {
                 // BackPanelController may set BackAnimationImpl's trigger bit while completing
@@ -1921,8 +2060,9 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             return true;
         }
 
-        protected boolean finishLegacyInterruptGesture(MotionEvent event, boolean allowTrigger)
+        protected boolean finishLegacyBackGesture(MotionEvent event, boolean allowTrigger)
                 throws Exception {
+            boolean openInterruption = legacyInterruptGesture;
             String panelStateBeforeRelease = readNativePanelState();
             boolean panelReleaseDelivered =
                     dispatchToEdgePlugin(event, activeEdge);
@@ -1943,12 +2083,18 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                     && exactReleaseOwner
                     && Boolean.TRUE.equals(nativePanelTrigger);
             if (trigger) {
-                // A normal BACK creates the incoming CLOSE/TO_BACK transition. Xiaomi's
-                // TransitionControllerImpl tags a consecutive inverse transition pair and
-                // DefaultTransitionImpl.mergeAnimation() reverses the running OPEN animators.
-                dispatchLegacyInterruptBack(releaseController);
+                if (openInterruption) {
+                    // A normal BACK creates the incoming CLOSE/TO_BACK transition. Xiaomi's
+                    // TransitionControllerImpl tags a consecutive inverse transition pair and
+                    // DefaultTransitionImpl.mergeAnimation() reverses the running OPEN animators.
+                    dispatchLegacyInterruptBack(releaseController);
+                } else {
+                    injectLegacyBackKey(releaseController);
+                }
             }
-            moduleLog(Log.INFO, TAG, "Finished MIUI in-app interrupt gesture"
+            moduleLog(Log.INFO, TAG, (openInterruption
+                    ? "Finished MIUI in-app interrupt gesture"
+                    : "Finished continuous legacy BACK fallback gesture")
                     + ", releaseAllowed=" + releaseAllowed
                     + ", nativePanelTrigger=" + nativePanelTrigger
                     + ", exactReleaseOwner=" + exactReleaseOwner
@@ -2001,29 +2147,14 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             boolean trigger = releaseAllowed
                     && exactReleaseOwner
                     && Boolean.TRUE.equals(nativePanelTrigger);
-            // This gesture never starts a Shell tracker. Clear any trigger value posted by
-            // BackPanelController after its release event, then hand a committed gesture to
-            // MiuiHome's own BackGestureBreakController.
+            // This gesture never starts a Shell tracker. During launcher-to-app OPEN, dispatch
+            // the same legacy BACK signal used by Xiaomi's normal interruption path. Starting
+            // predictive navigation here would queue a visually unrelated exit animation.
             clearControllerTriggerAfterVisualOnlyGesture();
             if (trigger) {
-                long generation = launcherOpenBreakGeneration;
-                long attemptId = launcherOpenBreakAttemptId;
-                pendingLauncherOpenBreakGeneration = generation;
-                pendingLauncherOpenBreakAttemptId = attemptId;
-                launcherOpenBreakCommandsInFlight.incrementAndGet();
-                try {
-                    sendAuthenticatedMiuiHomeOpenBreakCommand(
-                            context, generation, attemptId, this,
-                            releaseController);
-                } catch (Throwable throwable) {
-                    moduleLog(Log.ERROR, TAG, "Failed to send launcher OPEN break command",
-                            throwable);
-                    onLauncherOpenBreakCommandResult(generation, attemptId,
-                            LAUNCHER_OPEN_BREAK_RESULT_REJECTED, "sendException",
-                            releaseController);
-                }
+                injectLegacyBackKey(releaseController);
             }
-            moduleLog(Log.INFO, TAG, "Finished MiuiHome launcher OPEN break gesture"
+            moduleLog(Log.INFO, TAG, "Finished MiuiHome launcher OPEN legacy BACK gesture"
                     + ", trigger=" + trigger
                     + ", generation=" + launcherOpenBreakGeneration
                     + ", attempt=" + launcherOpenBreakAttemptId
@@ -2107,7 +2238,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                     || launcherShadeGesture || launcherDrawerGesture
                     || launcherEditingGesture;
             OpenTransitionSnapshot runningOpen = launcherCallbackOnly
-                    ? null : findReversibleRunningOpenTransition();
+                    ? null : findRunningOpenTransitionForLegacyBack();
             if (runningOpen != null) {
                 legacyInterruptGesture = true;
                 legacyRunningOpenInfo = runningOpen.transitionInfo;
@@ -2333,7 +2464,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                     }
                     return false;
                 }
-                runningOpen = findReversibleRunningOpenTransition();
+                runningOpen = findRunningOpenTransitionForLegacyBack();
                 if (receivedNull && runningOpen != null) {
                     cleanupRejectedShellGesture(session);
                     legacyInterruptGesture = true;
@@ -2504,13 +2635,15 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             }
         }
 
-        protected OpenTransitionSnapshot findReversibleRunningOpenTransition() {
+        protected OpenTransitionSnapshot findRunningOpenTransitionForLegacyBack() {
             OpenTransitionSnapshot active = null;
             for (OpenTransitionSnapshot snapshot : runningOpenTransitions.values()) {
-                if (snapshot.state.get() == OPEN_SNAPSHOT_ACTIVE) {
+                int state = snapshot.state.get();
+                if (state == OPEN_SNAPSHOT_PENDING
+                        || state == OPEN_SNAPSHOT_ACTIVE) {
                     if (active != null) {
                         moduleLog(Log.WARN, TAG,
-                                "Rejected ambiguous reversible OPEN transitions"
+                                "Rejected ambiguous running OPEN transitions"
                                         + ", firstInfo="
                                         + shortObject(active.transitionInfo)
                                         + ", secondInfo="
@@ -2521,7 +2654,8 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                 }
             }
             if (active != null) {
-                moduleLog(Log.INFO, TAG, "Detected reversible running OPEN transition"
+                moduleLog(Log.INFO, TAG, "Detected running OPEN transition for legacy BACK"
+                        + ", snapshotState=" + active.state.get()
                         + ", animatorCount=" + active.animators.length
                         + ", info=" + shortObject(active.transitionInfo));
             }
@@ -2649,12 +2783,14 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             shellGestureStartDeferred = false;
             gestureSuppressed = false;
             legacyInterruptGesture = false;
+            legacyBusyFallbackGesture = false;
             aospNullNavigationGesture = false;
             legacyRunningOpenInfo = null;
             launcherOpenBreakGesture = false;
             launcherOpenBreakGeneration = 0L;
             launcherOpenBreakAttemptId = 0L;
             launcherOverviewGesture = false;
+            acceptedLauncherOverviewForCurrentDown = false;
             launcherShadeGesture = false;
             launcherDrawerGesture = false;
             launcherEditingGesture = false;
@@ -3390,14 +3526,22 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                                 || (session.navigation == null
                                 && receivedNull
                                 != session.receivedNullNavigation)) {
-                            throw new IllegalStateException(
-                                    "Shell MOVE identity changed"
+                            session.moveFailed.set(true);
+                            session.legacyFallbackRequested.set(true);
+                            moduleLog(Log.WARN, TAG,
+                                    "Shell MOVE identity changed; preserving physical gesture"
+                                            + ", shellSessionId=" + session.id
                                             + ", tracker="
                                             + shortObject(tracker)
                                             + ", navigation="
                                             + shortObject(navigation)
                                             + ", receivedNull="
                                             + receivedNull);
+                            if (session.releaseQueued.compareAndSet(
+                                    false, true)) {
+                                cancelFailedShellRelease(session, tracker);
+                            }
+                            return;
                         }
                         applyProgressThresholds(tracker,
                                 session.linearDistance,

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -26,6 +26,12 @@
     <string name="hyperos_slide_animation_summary">以全宽侧滑替代 AOSP 预测性返回</string>
     <string name="module_logging_title">详细模块日志</string>
     <string name="module_logging_summary">保留信息日志；关闭后仍保留警告和错误日志</string>
+    <string name="aosp_background_black_title">返回动画纯黑背景</string>
+    <string name="aosp_background_black_summary">将 AOSP、HyperOS 及应用间返回动画的共同底板改为纯黑</string>
+    <string name="aosp_background_wallpaper_title">返回动画显示桌面壁纸</string>
+    <string name="aosp_background_wallpaper_summary">保留上下层 Activity，将 AOSP、HyperOS 及应用间返回的共同底板替换为当前壁纸快照</string>
+    <string name="aosp_wallpaper_blur_title">壁纸模糊（实验）</string>
+    <string name="aosp_wallpaper_blur_summary">尝试使用 HyperOS 合成器模糊壁纸底板；设备不支持时自动显示清晰壁纸</string>
     <string name="gesture_trigger_title">两侧触发区域</string>
     <string name="gesture_trigger_entry_title">两侧触发区域</string>
     <string name="gesture_trigger_entry_summary">调整左右两侧触发区域的高度和垂直位置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,12 @@
     <string name="hyperos_slide_animation_summary">Full-width slide instead of the AOSP predictive back</string>
     <string name="module_logging_title">Detailed module logs</string>
     <string name="module_logging_summary">Keep informational logs enabled; warnings and errors are always kept</string>
+    <string name="aosp_background_black_title">Pure black return background</string>
+    <string name="aosp_background_black_summary">Use a pure-black shared backdrop for AOSP, HyperOS, and cross-app return animations</string>
+    <string name="aosp_background_wallpaper_title">Show wallpaper during return</string>
+    <string name="aosp_background_wallpaper_summary">Keep both Activity targets and show the current wallpaper snapshot behind AOSP, HyperOS, and cross-app return animations</string>
+    <string name="aosp_wallpaper_blur_title">Wallpaper blur (experimental)</string>
+    <string name="aosp_wallpaper_blur_summary">Try the HyperOS compositor blur for the wallpaper backdrop; fall back to the clear wallpaper when unsupported</string>
     <string name="gesture_trigger_title">Side trigger area</string>
     <string name="gesture_trigger_entry_title">Side trigger area</string>
     <string name="gesture_trigger_entry_summary">Adjust the height and vertical position of both side trigger areas</string>


### PR DESCRIPTION
大佬您好，很荣幸能够用上您写的这个项目。

我在使用了一段时间后，感觉目前还有一些比较影响体验的小痛点，因此尝试通过 vibe coding 对项目进行了修改，并在自己的设备上持续复现和测试。

测试环境：

- 设备：Redmi K90 Pro Max
- 系统：HyperOS 3.0.23
- 测试桌面版本：`RELEASE-7.00.00.2300-06091632`

## 主要修改

### 1. Back to Home 动画兼容较低版本系统桌面

- 扩展了 MiuiHome 返回桌面动画的初始化入口、生命周期、RemoteTransition 和 WindowElement 状态适配。
- 兼容较低版本系统桌面中不同的类路径与回调时序；某个兼容 Hook 不存在时，不再影响文件夹返回、输入仲裁等其他独立功能。
- 增加动画对象、任务、generation 和 finish callback 的所有权校验，减少错误接管其他动画的风险。
- 修复返回桌面后、上一轮 Shell 动画尚未完成清理时立即再次打开桌面小组件，应用可能直接闪现而没有进入动画的问题。现在会等待对应动画完成清理后，再恢复小组件启动。
- 返回桌面的交互预览不再将窗口圆角插值到固定值，而是保持应用窗口原本的视觉圆角，减少动画过程中圆角突然变化的问题。

### 2. 支持在 Activity 原生进入动画期间执行返回手势

- 在 SystemUI 中记录正在等待或播放的 Xiaomi Activity OPEN transition。
- 如果返回手势发生在原生进入动画期间，不再启动另一套 AOSP 预测性退出动画，而是在手势提交时发送一次旧版普通 BACK 信号。
- 由 HyperOS 原生的 OPEN/CLOSE transition merge 路径反转或打断进入动画，避免出现“进入动画先播放完成，随后再播放一套风格不同的预测性返回动画”。
- 当弹窗消失、焦点窗口改变或 Shell tracker 被重置时，保留用户已经拉出的 BackPanel；如果预测性返回会话无法继续，则在同一次手势松手提交时降级为普通 BACK，不要求重新滑动。

### 3. 改进系统桌面中的返回手势仲裁

- 普通桌面空闲状态不再拦截屏幕边缘滑动，保留系统桌面的原生横向滑动。
- 桌面文件夹打开时可以交给 AOSP 返回路径处理。
- 增加对桌面后台任务界面（Overview）状态的识别和传递，避免只依赖存在延迟的状态广播。
- 对 MiuiHome 与 SystemUI 之间传递的输入增加 event、downTime、display、edge 和 generation 校验，避免旧输入或延迟状态错误接管新的手势。

### 4. 修复弹窗及连续手势相关问题

- 修复 Activity 上的弹窗自动消失后，数秒内无法再次唤出返回手势的问题。
- 修复已经拉出的返回手势随着弹窗消失或焦点切换一起被取消的问题。
- 当上一轮预测性返回仍占用 Shell 导航槽位时，允许新手势在满足条件后降级发送一次普通 BACK，避免手势完全失效。
- 保证一条物理手势最多提交一次返回信号，避免预测性返回和普通 BACK 同时触发。

### 5. 新增返回动画填充背景

设置中新增三种背景模式：

- 系统默认背景；
- 纯黑背景；
- 当前桌面壁纸快照。

这里修改的是两张浮动 Activity 背后的共同底板，不会隐藏下层 Activity，也不会改变上下层 Activity 自身的透明度、矩阵和相对层级。

背景生命周期接入系统共用的 `BackAnimationBackground`，用于覆盖：

- AOSP cross-activity 预测性返回；
- 从一个应用返回到另一个应用的 cross-task 返回；
- 接入相同公共背景生命周期的模块返回动画路径。

壁纸会按照屏幕比例居中裁剪，并按 wallpaper id 缓存快照，手势 MOVE 过程中不会重复读取或解码壁纸；动画结束或取消后会释放临时 SurfaceControl。

另外增加了实验性的 HyperOS 合成器壁纸模糊选项。模糊由 SurfaceFlinger 完成，当前 ROM 不支持对应接口时会自动退回清晰壁纸，不影响返回手势本身。

## 性能与稳定性处理

- 高频手势路径使用内存中的配置缓存，不在每一帧读取 RemotePreferences。
- 壁纸只在首次使用或 wallpaper id 变化后重新获取，不在动画帧中重复解码。
- 使用输入身份、动画对象和 generation 校验异步回调，降低旧状态影响下一次手势的可能。
- 无法确认动画或输入所有权时优先回退原有系统逻辑，不强行接管。
- 排障期间使用的临时高频诊断日志没有包含在本 PR 中。

## 构建验证

本地已经执行并通过：

- `assembleRelease`
- Release R8
- `lintVital`

以上修改主要通过 vibe coding 完成。我负责问题复现、提供系统桌面 APK 和 LSPosed 日志，并在上述真机环境中持续测试交互效果。由于这些实现涉及 HyperOS、SystemUI 和系统桌面的私有接口，不同系统版本上仍可能存在兼容性差异。

如果这个 PR 的改动范围过大，或者对项目现有结构具有较强的侵入性，还请大佬见谅。也非常欢迎您指出不合适的实现方式；如果需要拆分提交、精简功能或调整代码结构，我会尽力继续修改。感谢您抽时间审阅。
