### PR TITLE
feat: add redmi k90 hyperos4 support

### DIFF
--- a/experiments/miui-home-hyos-zn/README.md
+++ b/experiments/miui-home-hyos-zn/README.md
@@ -39,10 +39,17 @@ Shared native runtime:
 ```text
 hyos_spawner path:       /system_ext/bin/hyos_spawner
 hyos_spawner Build ID:   87f2632e7d68fda0226366fda5346c2d
-broadcast private ID:    7f186b331ec39d84e6016daeba65366f
+broadcast private IDs:   7f186b331ec39d84e6016daeba65366f (Xiaomi 17 Pro Max, OS4.0.0.20)
+                         c4fec5d3d810f76eff819d9379517a4a (Redmi K90, OS4.0.0.18)
 launcher process:        /proc/self/cmdline == com.miui.home
 entry symbol:            app_entry_point
 ```
+
+The broadcast-private dylib is per-ROM Build ID while its mangled symbols and
+GOT layout stay identical, so the arbiter-bridge gate accepts either ID. The
+`5334` profile has been validated on both the author's device and a Redmi K90
+(`annibale`, `OS4.0.0.18.XPKCNXM`, `MiuiSystemUI 17.03.260226.r`) with the
+full `verify-launcher-profiles.py` PASS.
 
 Launcher profiles:
 

--- a/experiments/miui-home-hyos-zn/zn_module.cpp
+++ b/experiments/miui-home-hyos-zn/zn_module.cpp
@@ -82,6 +82,13 @@ constexpr uint8_t kExpectedBroadcastPrivateBuildId[] = {
         0x7f, 0x18, 0x6b, 0x33, 0x1e, 0xc3, 0x9d, 0x84,
         0xe6, 0x01, 0x6d, 0xae, 0xba, 0x65, 0x36, 0x6f,
 };
+// Redmi K90 (annibale, OS4.0.0.18) ships the same broadcast-private dylib
+// layout with a different Build ID (c4fec5d3d810f76eff819d9379517a4a); the
+// arbiter-bridge gate accepts either one.
+constexpr uint8_t kExpectedBroadcastPrivateBuildIdK90[] = {
+        0xc4, 0xfe, 0xc5, 0xd3, 0xd8, 0x10, 0xf7, 0x6e,
+        0xff, 0x81, 0x9d, 0x93, 0x79, 0x51, 0x7a, 0x4a,
+};
 
 using DlopenFn = void* (*)(const char*, int);
 using AndroidDlopenExtFn = void* (*)(const char*, int,
@@ -988,7 +995,10 @@ bool InstallBroadcastIntentWithFeatureGot(void* resolved) {
     AtomicStore(&g_native_receiver_state, uint32_t{100});
     if (!ValidateElfBuildId(kBroadcastPrivatePath,
                     kExpectedBroadcastPrivateBuildId,
-                    sizeof(kExpectedBroadcastPrivateBuildId))) {
+                    sizeof(kExpectedBroadcastPrivateBuildId)) &&
+            !ValidateElfBuildId(kBroadcastPrivatePath,
+                    kExpectedBroadcastPrivateBuildIdK90,
+                    sizeof(kExpectedBroadcastPrivateBuildIdK90))) {
         AtomicStore(&g_native_receiver_state, uint32_t{101});
         return false;
     }


### PR DESCRIPTION
似乎唯一区别是 buildid 不同，让ai适配了一下，支持多个 build id

<img width="1156" height="2510" alt="image" src="https://github.com/user-attachments/assets/b8bbd339-b301-4ce4-881b-76a23387ef6f" />
