### PR TITLE
support os3 rust

### DIFF
--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
@@ -5,6 +5,8 @@ import android.animation.AnimatorListenerAdapter;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.content.SharedPreferences;
 import android.graphics.Rect;
 import android.os.Build;
@@ -165,6 +167,8 @@ public abstract class HookRuntimeCore extends XposedModule {
             "com.miui.home.launcher.Application";
     protected static final String MIUI_HOME_OVERVIEW_PROXY_IMPL =
             "com.miui.home.recents.OverviewProxyImpl";
+    protected static final String MIUI_HOME_TOUCH_INTERACTION_SERVICE =
+            "com.miui.home.recents.TouchInteractionService$1";
     protected static final String MIUI_HOME_REMOTE_ANIMATION_TARGET_COMPAT =
             "com.android.systemui.shared.recents.system.RemoteAnimationTargetCompat";
     protected static final String MIUI_HOME_REMOTE_ANIMATION_TARGET_SET =
@@ -290,6 +294,8 @@ public abstract class HookRuntimeCore extends XposedModule {
             "dev.codex.miuibackgesturehook.action.MIUI_HOME_INPUT_ARBITER_QUERY";
     protected static final String MODULE_CONTEXTUAL_SEARCH_TRIGGERED =
             "dev.codex.miuibackgesturehook.action.CONTEXTUAL_SEARCH_TRIGGERED";
+    protected static final String MODULE_CONTEXTUAL_SEARCH_SERVICE =
+            "dev.codex.miuibackgesturehook.action.CONTEXTUAL_SEARCH_SERVICE";
     protected static final String MODULE_RUNTIME_STATUS_QUERY =
             ZnStatusProtocol.ACTION_QUERY;
     protected static final String MODULE_RUNTIME_STATUS_REPLY =
@@ -560,6 +566,25 @@ public abstract class HookRuntimeCore extends XposedModule {
      */
     protected static boolean blockMiuiHomeXposedHooks() {
         return Build.VERSION.SDK_INT >= ANDROID_17_API_LEVEL;
+    }
+    
+    protected boolean isRustHome(Context context) {
+        try {
+            ApplicationInfo appInfo = context.getPackageManager().getApplicationInfo(
+                MIUI_HOME,
+                PackageManager.GET_SHARED_LIBRARY_FILES
+            );
+            String[] sharedLibraries = appInfo.sharedLibraryFiles;
+            if (sharedLibraries != null) {
+                for (String libPath : sharedLibraries) {
+                    if (libPath != null && libPath.contains("hyperos.rustruntime")) {
+                        return true;
+                    }
+                }
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+        }
+        return false;
     }
 
     protected static boolean isMiuiHomeProcess(String candidate) {

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
@@ -3249,7 +3249,7 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
         try {
             boolean contextualSearchEnabled =
                     isContextualSearchLongPressRuntimeEnabled();
-            Intent stateIntent = new Intent(systemUiInputArbiterStateAction());
+            Intent stateIntent = new Intent(systemUiInputArbiterStateAction(context));
             stateIntent.setPackage(MIUI_HOME);
             stateIntent.putExtra(EXTRA_INPUT_ARBITER_READY, ready);
             stateIntent.putExtra(EXTRA_INPUT_ARBITER_GENERATION,

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
@@ -140,8 +140,14 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
 
     protected void hookMiuiHomeReturnHomeInitialize(ClassLoader classLoader)
             throws ClassNotFoundException, NoSuchMethodException {
-        Class<?> overviewProxyClass = Class.forName(MIUI_HOME_OVERVIEW_PROXY_IMPL, false,
-                classLoader);
+        Class<?> overviewProxyClass;
+        try {
+            overviewProxyClass = Class.forName(MIUI_HOME_OVERVIEW_PROXY_IMPL, false,
+                    classLoader);
+        } catch(ClassNotFoundException e) {
+            overviewProxyClass = Class.forName(MIUI_HOME_TOUCH_INTERACTION_SERVICE, false,
+            classLoader);
+        }
         Method method = overviewProxyClass.getDeclaredMethod(
                 "lambda$onInitialize$0", Bundle.class);
         method.setAccessible(true);

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
@@ -6260,6 +6260,23 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
                     playContextualSearchHaptic(receiverContext);
                     return;
                 }
+                 if (MODULE_CONTEXTUAL_SEARCH_SERVICE.equals(action)) {
+                    int senderUid = getSentFromUid();
+                    String senderPackage = getSentFromPackage();
+                    if (!isTrustedMiuiHomeBroadcastSender(
+                            receiverContext, senderUid, senderPackage)) {
+                        moduleLog(Log.WARN, TAG,
+                                "Rejected untrusted contextual-search trigger"
+                                        + ", uid=" + senderUid
+                                        + ", package=" + senderPackage);
+                        return;
+                    }
+                    if (!invokeContextualSearchService()) {
+                        return;
+                    }
+                    playContextualSearchHaptic(receiverContext);
+                    return;
+                }
                 if (!MODULE_MIUI_OVERVIEW_STATE_CHANGE.equals(action)
                         && !MODULE_MIUI_HOME_INPUT_ARBITER_QUERY.equals(action)) {
                     return;
@@ -6377,6 +6394,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
             IntentFilter filter = new IntentFilter(MODULE_MIUI_OVERVIEW_STATE_CHANGE);
             filter.addAction(MODULE_MIUI_HOME_INPUT_ARBITER_QUERY);
             filter.addAction(MODULE_CONTEXTUAL_SEARCH_TRIGGERED);
+            filter.addAction(MODULE_CONTEXTUAL_SEARCH_SERVICE);
             filter.addAction(MODULE_RUNTIME_STATUS_QUERY);
             filter.addAction(MODULE_RUNTIME_STATUS_REPLY);
             appContext.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
@@ -6502,7 +6520,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
         sendModuleRuntimeStatusReply(context, nonce, false, ready,
                 "systemUiResponse", null);
         try {
-            Intent nativeQuery = new Intent(systemUiInputArbiterStateAction())
+            Intent nativeQuery = new Intent(isRustHome(context) ? "com.android.systemui.fsgesture" : MODULE_SYSTEMUI_INPUT_ARBITER_STATE)
                     .setPackage(MIUI_HOME)
                     .putExtra(EXTRA_STATUS_QUERY, true)
                     .putExtra(EXTRA_STATUS_NONCE, nonce)
@@ -6565,8 +6583,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
                     .setPackage(MODULE_PACKAGE)
                     .putExtra(EXTRA_STATUS_NONCE, nonce)
                     .putExtra(EXTRA_STATUS_NATIVE_RESPONSE, nativeResponse)
-                    .putExtra(EXTRA_STATUS_LEGACY_MODE,
-                            Build.VERSION.SDK_INT < ANDROID_17_API_LEVEL)
+                    .putExtra(EXTRA_STATUS_LEGACY_MODE, !isRustHome(context))
                     .putExtra(EXTRA_STATUS_SYSTEMUI_READY, systemUiReady)
                     .putExtra(EXTRA_STATUS_SYSTEMUI_GENERATION,
                             systemUiInputArbiterGeneration)

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
@@ -249,12 +249,12 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
         return requireSystemUiPlatformImpl().defaultTransitionOpenCaptureHookId();
     }
 
-    protected String systemUiInputArbiterStateAction() {
+    protected String systemUiInputArbiterStateAction(Context context) {
         SystemUiPlatformImpl implementation = systemUiPlatformImpl;
         return implementation == null
                 ? MODULE_SYSTEMUI_INPUT_ARBITER_STATE
                 : implementation.systemUiInputArbiterStateAction(
-                        MODULE_SYSTEMUI_INPUT_ARBITER_STATE);
+                        isRustHome(context) ? "com.android.systemui.fsgesture" : MODULE_SYSTEMUI_INPUT_ARBITER_STATE);
     }
 
     protected void hookPlatformBackAnimationStatusBarReset(ClassLoader classLoader) {
@@ -6520,7 +6520,7 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
         sendModuleRuntimeStatusReply(context, nonce, false, ready,
                 "systemUiResponse", null);
         try {
-            Intent nativeQuery = new Intent(isRustHome(context) ? "com.android.systemui.fsgesture" : MODULE_SYSTEMUI_INPUT_ARBITER_STATE)
+            Intent nativeQuery = new Intent(systemUiInputArbiterStateAction(context))
                     .setPackage(MIUI_HOME)
                     .putExtra(EXTRA_STATUS_QUERY, true)
                     .putExtra(EXTRA_STATUS_NONCE, nonce)

--- a/miui-home-hyos-zn/zn_module.cpp
+++ b/miui-home-hyos-zn/zn_module.cpp
@@ -59,8 +59,12 @@ constexpr char kAppPublicPath[] =
 constexpr char kAppPublicName[] = "libhyper_os_app_public.so";
 constexpr char kBroadcastPrivatePath[] =
         "/system_ext/lib64/libhyper_os_broadcast_private.dylib.so";
-constexpr uintptr_t kBroadcastIntentWithFeatureGotOffset = 0x1d1c0u;
-constexpr uintptr_t kBroadcastIntentWithFeatureSymbolOffset = 0x1a7ccu;
+uintptr_t kBroadcastIntentWithFeatureGotOffset = 0u;
+constexpr uintptr_t kBroadcastIntentWithFeatureGotOffsetOS3 = 0x1d1c0u;
+constexpr uintptr_t kBroadcastIntentWithFeatureGotOffsetOS4 = 0x14ed0u;
+uintptr_t kBroadcastIntentWithFeatureSymbolOffset = 0u;
+constexpr uintptr_t kBroadcastIntentWithFeatureSymbolOffsetOS3 = 0x1a7ccu;
+constexpr uintptr_t kBroadcastIntentWithFeatureSymbolOffsetOS4 = 0x10d74u;
 const char* kBroadcastReceiverOnReceiveSymbol = nullptr;
 constexpr char kBroadcastReceiverOnReceiveSymbolOS3[] =
         "_RNvMs3_NtNtCsamj2hZJmyn0_26hyper_os_broadcast_private13dyn_"
@@ -642,12 +646,16 @@ bool ValidateElfBuildId(const char* path, const uint8_t* expected,
 bool ValidateSpawnerBuildId() {
     if (ValidateElfBuildId(kSpawnerPath, kExpectedSpawnerBuildIdOS3,
                               sizeof(kExpectedSpawnerBuildIdOS3))) {
+        kBroadcastIntentWithFeatureGotOffset = kBroadcastIntentWithFeatureGotOffsetOS3;
+        kBroadcastIntentWithFeatureSymbolOffset = kBroadcastIntentWithFeatureSymbolOffsetOS3;
         kBroadcastReceiverOnReceiveSymbol = kBroadcastReceiverOnReceiveSymbolOS3;
         kBroadcastIntentWithFeatureSymbol = kBroadcastIntentWithFeatureSymbolOS3;
         return true;
     };
     if (ValidateElfBuildId(kSpawnerPath, kExpectedSpawnerBuildIdOS4,
                               sizeof(kExpectedSpawnerBuildIdOS4))) {
+        kBroadcastIntentWithFeatureGotOffset = kBroadcastIntentWithFeatureGotOffsetOS4;
+        kBroadcastIntentWithFeatureSymbolOffset = kBroadcastIntentWithFeatureSymbolOffsetOS4;
         kBroadcastReceiverOnReceiveSymbol = kBroadcastReceiverOnReceiveSymbolOS4;
         kBroadcastIntentWithFeatureSymbol = kBroadcastIntentWithFeatureSymbolOS4;
         return true;

--- a/miui-home-hyos-zn/zn_module.cpp
+++ b/miui-home-hyos-zn/zn_module.cpp
@@ -59,13 +59,23 @@ constexpr char kAppPublicPath[] =
 constexpr char kAppPublicName[] = "libhyper_os_app_public.so";
 constexpr char kBroadcastPrivatePath[] =
         "/system_ext/lib64/libhyper_os_broadcast_private.dylib.so";
-constexpr uintptr_t kBroadcastIntentWithFeatureGotOffset = 0x14ed0u;
-constexpr uintptr_t kBroadcastIntentWithFeatureSymbolOffset = 0x10d74u;
-constexpr char kBroadcastReceiverOnReceiveSymbol[] =
-        "_RNvMs3_NtNtCslLvADlVgqlk_26hyper_os_broadcast_private13dyn_"
+constexpr uintptr_t kBroadcastIntentWithFeatureGotOffset = 0x1d1c0u;
+constexpr uintptr_t kBroadcastIntentWithFeatureSymbolOffset = 0x1a7ccu;
+const char* kBroadcastReceiverOnReceiveSymbol = nullptr;
+constexpr char kBroadcastReceiverOnReceiveSymbolOS3[] =
+        "_RNvMs3_NtNtCsamj2hZJmyn0_26hyper_os_broadcast_private13dyn_"
         "broadcast23BroadcastReceiver_traitINtB5_20BroadcastReceiver_TOINtNtNtNt"
-        "Cs9Neji4M1weT_10abi_stable9std_types5boxed7private4RBoxuEE10on_receiveB9_";
-constexpr char kBroadcastIntentWithFeatureSymbol[] =
+        "Csc8ZqGyuZgC9_10abi_stable9std_types5boxed7private4RBoxuEE10on_receiveB9_";
+constexpr char kBroadcastReceiverOnReceiveSymbolOS4[] =
+         "_RNvMs3_NtNtCslLvADlVgqlk_26hyper_os_broadcast_private13dyn_"
+         "broadcast23BroadcastReceiver_traitINtB5_20BroadcastReceiver_TOINtNtNtNt"
+         "Cs9Neji4M1weT_10abi_stable9std_types5boxed7private4RBoxuEE10on_receiveB9_";
+const char* kBroadcastIntentWithFeatureSymbol = nullptr;
+constexpr char kBroadcastIntentWithFeatureSymbolOS3[] =
+        "_RNvXs_NtCsamj2hZJmyn0_26hyper_os_broadcast_private8sys_implNtB4_31"
+        "ActivityManagerServiceProxyImplNtB4_27ActivityManagerServiceProxy26"
+        "broadcastIntentWithFeature";
+constexpr char kBroadcastIntentWithFeatureSymbolOS4[] =
         "_RNvXs_NtCslLvADlVgqlk_26hyper_os_broadcast_private8sys_implNtB4_31"
         "ActivityManagerServiceProxyImplNtB4_27ActivityManagerServiceProxy26"
         "broadcastIntentWithFeature";
@@ -75,7 +85,11 @@ constexpr char kDataLauncherLibraryTail[] =
 constexpr char kSystemLauncherLibraryTail[] =
         "/MiuiHome.apk!/lib/arm64-v8a/libapp_launcher.so";
 constexpr char kLauncherEntrySymbol[] = "app_entry_point";
-constexpr uint8_t kExpectedSpawnerBuildId[] = {
+constexpr uint8_t kExpectedSpawnerBuildIdOS3[] = {
+        0x9d, 0xf1, 0x7e, 0x1f, 0xab, 0xfd, 0x23, 0x0f,
+        0xb8, 0x25, 0x37, 0x06, 0x70, 0x5d, 0x8b, 0xc8,
+};
+constexpr uint8_t kExpectedSpawnerBuildIdOS4[] = {
         0x87, 0xf2, 0x63, 0x2e, 0x7d, 0x68, 0xfd, 0xa0,
         0x22, 0x63, 0x66, 0xfd, 0xa5, 0x34, 0x6c, 0x2d,
 };
@@ -626,8 +640,19 @@ bool ValidateElfBuildId(const char* path, const uint8_t* expected,
 }
 
 bool ValidateSpawnerBuildId() {
-    return ValidateElfBuildId(kSpawnerPath, kExpectedSpawnerBuildId,
-                              sizeof(kExpectedSpawnerBuildId));
+    if (ValidateElfBuildId(kSpawnerPath, kExpectedSpawnerBuildIdOS3,
+                              sizeof(kExpectedSpawnerBuildIdOS3))) {
+        kBroadcastReceiverOnReceiveSymbol = kBroadcastReceiverOnReceiveSymbolOS3;
+        kBroadcastIntentWithFeatureSymbol = kBroadcastIntentWithFeatureSymbolOS3;
+        return true;
+    };
+    if (ValidateElfBuildId(kSpawnerPath, kExpectedSpawnerBuildIdOS4,
+                              sizeof(kExpectedSpawnerBuildIdOS4))) {
+        kBroadcastReceiverOnReceiveSymbol = kBroadcastReceiverOnReceiveSymbolOS4;
+        kBroadcastIntentWithFeatureSymbol = kBroadcastIntentWithFeatureSymbolOS4;
+        return true;
+    };
+    return false;
 }
 
 bool IsExplicitlyEnabled() {
@@ -695,6 +720,8 @@ constexpr char kArbiterQueryAction[] =
         "dev.codex.miuibackgesturehook.action.MIUI_HOME_INPUT_ARBITER_QUERY";
 constexpr char kContextualSearchTriggeredAction[] =
         "dev.codex.miuibackgesturehook.action.CONTEXTUAL_SEARCH_TRIGGERED";
+constexpr char kContextualSearchServiceAction[] =
+        "dev.codex.miuibackgesturehook.action.CONTEXTUAL_SEARCH_SERVICE";
 constexpr char kRuntimeStatusResponseAction[] =
         "dev.codex.miuibackgesturehook.action.RUNTIME_STATUS_REPLY";
 constexpr char kRuntimeStatusQueryExtra[] = "status_query";
@@ -2461,6 +2488,10 @@ void HookContextualLongPressHandler(void* closure, uint32_t trigger_mode) {
             kContextualSearchTriggeredAction, nullptr)) {
         Log(ANDROID_LOG_WARN,
             "contextual-search trigger haptic signal could not reach SystemUI");
+    } else if (!SendNativeBroadcast(
+            kContextualSearchServiceAction, nullptr)) {
+        Log(ANDROID_LOG_WARN,
+            "contextual-search service signal could not reach SystemUI");
     }
     if (!CleanupContextualLongPressClosure(closure)) {
         // This should be unreachable after the validation above.  Keep the


### PR DESCRIPTION
为 HyperOS 3 补全的 rust 库做对应支持(os3 必须用这个补全库)
已在 K70 使用 5436 桌面测试模块功能正常，其他桌面动画受 rust 环境问题影响，仅供娱乐尝鲜!

rust补全模块 [https://1818959180.share.123pan.cn/123pan/awkAjv-mJja](https://1818959180.share.123pan.cn/123pan/awkAjv-mJja)

<img width="1440" height="3200" alt="Screenshot_2026-08-22-10-33-01-612_com android settings" src="https://github.com/user-attachments/assets/b75ce2bd-4ff7-4c20-b8f9-c1a37e1b2c2e" />
