### PR TITLE
fix: resolve Android 17 native hooks dynamically

### DIFF
--- a/miui-home-hyos-native/README.md
+++ b/miui-home-hyos-native/README.md
@@ -17,6 +17,19 @@ Launcher business hooks, profile validation, the runtime/Dart resolvers,
 authenticated state broadcasts, and the MiCTS-style `madvise` guard are built
 into this APK payload.
 
+The private-broadcast bridge resolves its exact Rust dynamic symbol in the
+loaded system image and then requires exactly one matching
+`R_AARCH64_JUMP_SLOT` from `DT_JMPREL`. It does not carry build-specific
+function or GOT offsets. Image ownership, the resolved slot value, RELRO page
+handling, and rollback remain fail-closed guards; missing or ambiguous
+relocations leave the bridge disabled.
+
+The mapped Dart AOT resolver also carries no launcher-version callback RVAs.
+When the compiler emits paired Overview-enter callbacks, it selects the upper
+adjacent pool-object member only after it uniquely shares the exit callback's
+state slot, shared object, and prepare/publish call targets. Missing, oversized,
+or multiply paired candidate families reject the whole Dart state profile.
+
 ## Build
 
 Use the application build; there is no separate native-module package task:

--- a/miui-home-hyos-native/dart_runtime_resolver.cpp
+++ b/miui-home-hyos-native/dart_runtime_resolver.cpp
@@ -8,6 +8,7 @@ namespace {
 
 constexpr size_t kMaxLoadSegments = 16u;
 constexpr uintptr_t kMaxImageSpan = 0x4000000u;
+constexpr size_t kMaxOverviewCandidates = 16u;
 
 struct LoadSegment {
     uintptr_t start;
@@ -32,6 +33,7 @@ struct DrawerCandidate {
 struct OverviewCandidate {
     uintptr_t offset;
     uintptr_t state_slot;
+    uintptr_t argument_pool_object;
     uintptr_t shared_pool_object;
     uintptr_t prepare_target;
     uintptr_t publish_target;
@@ -282,10 +284,11 @@ bool MatchOverviewEnter(const ElfView& view, uintptr_t offset,
         // insert two pool loads and use relocated field offsets. Keep the
         // structural ABI checks while allowing those compiler-generated
         // immediates to move.
+        uintptr_t modern_state = 0u;
         if (code[0] != 0xa9bf79fdu || code[1] != 0xaa0f03fdu ||
                 code[2] != 0xd10041efu || code[3] != 0xaa0103e2u ||
                 code[4] != 0xf81f83a1u || code[5] != 0xf9403f40u ||
-                !IsLoadX0FromX0(code[6], nullptr) ||
+                !IsLoadX0FromX0(code[6], &modern_state) ||
                 code[7] != 0xf9402370u || code[8] != 0x6b10001fu ||
                 code[9] != 0x54000061u || !DecodeBlTarget(
                         offset + 11u * 4u, code[11], &unbox) ||
@@ -302,9 +305,12 @@ bool MatchOverviewEnter(const ElfView& view, uintptr_t offset,
                 code[28] != 0xd65f03c0u) {
             return false;
         }
-    }
-        *candidate = {offset, state_slot, shared, prepare, publish};
+        *candidate = {offset, modern_state, argument, shared, prepare,
+                      publish};
         return true;
+    }
+    *candidate = {offset, state_slot, argument, shared, prepare, publish};
+    return true;
 }
 
 bool MatchOverviewExit(const ElfView& view, uintptr_t offset,
@@ -364,11 +370,83 @@ bool MatchOverviewExit(const ElfView& view, uintptr_t offset,
                 code[42] != 0xa8c179fdu || code[43] != 0xd65f03c0u) {
             return false;
         }
-        *candidate = {offset, modern_state, modern_shared, modern_prepare,
-                      modern_publish};
+        *candidate = {offset, modern_state, 0u, modern_shared,
+                      modern_prepare, modern_publish};
         return true;
     }
-    *candidate = {offset, state_slot, shared, prepare, publish};
+    *candidate = {offset, state_slot, 0u, shared, prepare, publish};
+    return true;
+}
+
+bool SameOverviewFamily(const OverviewCandidate& enter,
+                        const OverviewCandidate& exit) {
+    return enter.state_slot != 0u &&
+            enter.state_slot == exit.state_slot &&
+            enter.shared_pool_object != 0u &&
+            enter.shared_pool_object == exit.shared_pool_object &&
+            enter.prepare_target != 0u &&
+            enter.prepare_target == exit.prepare_target &&
+            enter.publish_target != 0u &&
+            enter.publish_target == exit.publish_target;
+}
+
+bool SelectOverviewPair(const OverviewCandidate* enters, size_t enter_count,
+                        const OverviewCandidate* exits, size_t exit_count,
+                        OverviewCandidate* selected_enter,
+                        OverviewCandidate* selected_exit) {
+    if (enters == nullptr || exits == nullptr || selected_enter == nullptr ||
+            selected_exit == nullptr || enter_count == 0u ||
+            exit_count == 0u || enter_count > kMaxOverviewCandidates ||
+            exit_count > kMaxOverviewCandidates) {
+        return false;
+    }
+    if (enter_count == 1u && exit_count == 1u &&
+            SameOverviewFamily(enters[0], exits[0])) {
+        *selected_enter = enters[0];
+        *selected_exit = exits[0];
+        return true;
+    }
+
+    // Recent Dart AOT snapshots emit two otherwise identical enter callbacks
+    // from adjacent pool objects. The callback for entering Overview uses the
+    // upper object; its lower adjacent sibling is the complementary callback.
+    // Require that pairing in addition to the unique exit callback's state,
+    // shared object, and prepare/publish targets. This keeps selection dynamic
+    // while failing closed for unrelated or multiply paired callback families.
+    size_t pair_count = 0u;
+    OverviewCandidate resolved_enter{};
+    OverviewCandidate resolved_exit{};
+    for (size_t exit_index = 0u; exit_index < exit_count; ++exit_index) {
+        for (size_t enter_index = 0u; enter_index < enter_count;
+             ++enter_index) {
+            const OverviewCandidate& enter = enters[enter_index];
+            const OverviewCandidate& exit = exits[exit_index];
+            if (!SameOverviewFamily(enter, exit) ||
+                    enter.argument_pool_object < sizeof(uint64_t)) {
+                continue;
+            }
+            size_t lower_sibling_count = 0u;
+            for (size_t sibling_index = 0u; sibling_index < enter_count;
+                 ++sibling_index) {
+                if (sibling_index == enter_index) continue;
+                const OverviewCandidate& sibling = enters[sibling_index];
+                if (SameOverviewFamily(sibling, exit) &&
+                        sibling.argument_pool_object <=
+                                UINTPTR_MAX - sizeof(uint64_t) &&
+                        sibling.argument_pool_object + sizeof(uint64_t) ==
+                                enter.argument_pool_object) {
+                    ++lower_sibling_count;
+                }
+            }
+            if (lower_sibling_count != 1u) continue;
+            ++pair_count;
+            resolved_enter = enter;
+            resolved_exit = exit;
+        }
+    }
+    if (pair_count != 1u) return false;
+    *selected_enter = resolved_enter;
+    *selected_exit = resolved_exit;
     return true;
 }
 
@@ -521,6 +599,8 @@ bool ResolveDartFeatureProfile(
     diagnostics->stage = ResolveStage::kResolvingOverview;
     OverviewCandidate enter{};
     OverviewCandidate exit{};
+    OverviewCandidate enter_candidates[kMaxOverviewCandidates]{};
+    OverviewCandidate exit_candidates[kMaxOverviewCandidates]{};
     for (size_t segment_index = 0u; segment_index < view.load_count;
          ++segment_index) {
         const LoadSegment& load = view.loads[segment_index];
@@ -530,39 +610,32 @@ bool ResolveDartFeatureProfile(
             OverviewCandidate candidate{};
             if (MatchOverviewEnter(view, offset, drawer.unbox_target,
                                    &candidate)) {
+                const uint32_t candidate_index =
+                        diagnostics->overview_enter_candidate_count;
+                if (candidate_index < kMaxOverviewCandidates) {
+                    enter_candidates[candidate_index] = candidate;
+                }
                 Increment(&diagnostics->overview_enter_candidate_count);
-                enter = candidate;
             }
             candidate = {};
             if (MatchOverviewExit(view, offset, drawer.unbox_target,
                                   &candidate)) {
+                const uint32_t candidate_index =
+                        diagnostics->overview_exit_candidate_count;
+                if (candidate_index < kMaxOverviewCandidates) {
+                    exit_candidates[candidate_index] = candidate;
+                }
                 Increment(&diagnostics->overview_exit_candidate_count);
-                exit = candidate;
             }
             offset += 4u;
         }
     }
-    if (launcher_profile.id != nullptr &&
-            strcmp(launcher_profile.id, "6144") == 0 &&
-            instructions_offset == 0x826940u) {
-        OverviewCandidate modern_enter{};
-        OverviewCandidate modern_exit{};
-        if (MatchOverviewEnter(view, 0x16c543cu, drawer.unbox_target,
-                               &modern_enter) &&
-                MatchOverviewExit(view, 0xdb8a70u, drawer.unbox_target,
-                                  &modern_exit)) {
-            enter = modern_enter;
-            exit = modern_exit;
-            diagnostics->overview_enter_candidate_count = 1u;
-            diagnostics->overview_exit_candidate_count = 1u;
-        }
-    }
-    if (diagnostics->overview_enter_candidate_count != 1u ||
-            diagnostics->overview_exit_candidate_count != 1u ||
-            enter.state_slot != exit.state_slot ||
-            enter.shared_pool_object != exit.shared_pool_object ||
-            enter.prepare_target != exit.prepare_target ||
-            enter.publish_target != exit.publish_target) {
+    if (!SelectOverviewPair(
+                enter_candidates,
+                diagnostics->overview_enter_candidate_count,
+                exit_candidates,
+                diagnostics->overview_exit_candidate_count,
+                &enter, &exit)) {
         diagnostics->stage = ResolveStage::kRejectedOverview;
         return false;
     }

--- a/miui-home-hyos-native/lsposed_hook_backend.cpp
+++ b/miui-home-hyos-native/lsposed_hook_backend.cpp
@@ -588,6 +588,30 @@ bool SymbolNameEquals(const DynamicView& view, uint32_t symbol_index,
             memcmp(name, expected, length) == 0;
 }
 
+void** FindUniquePltSlot(const Image& image, const DynamicView& view,
+                         const char* symbol) {
+    if (symbol == nullptr || view.plt_rela == nullptr ||
+            view.plt_rela_count == 0u) {
+        return nullptr;
+    }
+    void** matched = nullptr;
+    for (size_t index = 0u; index < view.plt_rela_count; ++index) {
+        const ElfW(Rela)& relocation = view.plt_rela[index];
+        if (ELF64_R_TYPE(relocation.r_info) != R_AARCH64_JUMP_SLOT) {
+            continue;
+        }
+        const uint32_t symbol_index = ELF64_R_SYM(relocation.r_info);
+        if (!SymbolNameEquals(view, symbol_index, symbol)) continue;
+        const uintptr_t address = RuntimeAddress(image, relocation.r_offset);
+        if (matched != nullptr || address == 0u ||
+                !RangeInImage(image, address, sizeof(void*), PF_R | PF_W)) {
+            return nullptr;
+        }
+        matched = reinterpret_cast<void**>(address);
+    }
+    return matched;
+}
+
 int ReadProtection(uintptr_t address) {
     FILE* maps = fopen("/proc/self/maps", "re");
     if (maps == nullptr) return -1;
@@ -772,6 +796,14 @@ void* LookupNativeSymbol(NativeSymbolResolver* resolver, const char* name,
         return reinterpret_cast<void*>(address);
     }
     return nullptr;
+}
+
+void** LookupNativePltSlot(NativeSymbolResolver* resolver, const char* name) {
+    if (resolver == nullptr || name == nullptr) return nullptr;
+    auto* bridge = reinterpret_cast<NativeSymbolResolverImpl*>(resolver);
+    DynamicView view{};
+    if (!BuildDynamicView(bridge->image, &view)) return nullptr;
+    return FindUniquePltSlot(bridge->image, view, name);
 }
 
 bool EnsureLsposedMadviseGuard(const char* runtime_name) {

--- a/miui-home-hyos-native/lsposed_hook_backend.h
+++ b/miui-home-hyos-native/lsposed_hook_backend.h
@@ -22,3 +22,6 @@ void FreeNativeSymbolResolver(NativeSymbolResolver* resolver);
 void* GetNativeBaseAddress(NativeSymbolResolver* resolver);
 void* LookupNativeSymbol(NativeSymbolResolver* resolver, const char* name,
                          bool prefix, size_t* size);
+// Returns the sole R_AARCH64_JUMP_SLOT for an exact dynamic symbol name.
+// The lookup is read-only and fails closed for missing or ambiguous slots.
+void** LookupNativePltSlot(NativeSymbolResolver* resolver, const char* name);

--- a/miui-home-hyos-native/miui_home_native_hook.cpp
+++ b/miui-home-hyos-native/miui_home_native_hook.cpp
@@ -9,6 +9,7 @@
 #include <elf.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -92,8 +93,6 @@ constexpr char kSpawnerPath[] = "/system_ext/bin/hyos_spawner";
 constexpr char kHyperRuntimeName[] = "libhyper_os_flutter.so";
 constexpr char kBroadcastPrivatePath[] =
         "/system_ext/lib64/libhyper_os_broadcast_private.dylib.so";
-constexpr uintptr_t kBroadcastIntentWithFeatureGotOffset = 0x14ed0u;
-constexpr uintptr_t kBroadcastIntentWithFeatureSymbolOffset = 0x10d74u;
 constexpr char kBroadcastReceiverOnReceiveSymbol[] =
         "_RNvMs3_NtNtCslLvADlVgqlk_26hyper_os_broadcast_private13dyn_"
         "broadcast23BroadcastReceiver_traitINtB5_20BroadcastReceiver_TOINtNtNtNt"
@@ -1297,25 +1296,21 @@ bool RestoreBroadcastIntentWithFeatureGot() {
     return restored && protected_again;
 }
 
-bool InstallBroadcastIntentWithFeatureGot(void* resolved) {
+bool InstallBroadcastIntentWithFeatureGot(void* resolved, void* expected_base,
+                                          void** slot) {
     AtomicStore(&g_native_receiver_state, uint32_t{100});
     Dl_info image{};
     if (resolved == nullptr || dladdr(resolved, &image) == 0 ||
             image.dli_fbase == nullptr || image.dli_fname == nullptr ||
-            !StringsEqual(image.dli_fname, kBroadcastPrivatePath)) {
+            !StringsEqual(image.dli_fname, kBroadcastPrivatePath) ||
+            image.dli_fbase != expected_base) {
         AtomicStore(&g_native_receiver_state, uint32_t{102});
         return false;
     }
-    const uintptr_t resolved_address = reinterpret_cast<uintptr_t>(resolved);
-    if (resolved_address < kBroadcastIntentWithFeatureSymbolOffset ||
-            reinterpret_cast<uintptr_t>(image.dli_fbase) !=
-            resolved_address - kBroadcastIntentWithFeatureSymbolOffset) {
+    if (slot == nullptr) {
         AtomicStore(&g_native_receiver_state, uint32_t{103});
         return false;
     }
-    auto** slot = reinterpret_cast<void**>(
-            static_cast<uint8_t*>(image.dli_fbase) +
-            kBroadcastIntentWithFeatureGotOffset);
     if (AtomicLoad(slot) != resolved) {
         AtomicStore(&g_native_receiver_state, uint32_t{104});
         return false;
@@ -1338,6 +1333,14 @@ bool InstallBroadcastIntentWithFeatureGot(void* resolved) {
     const bool protected_again = SetBroadcastPrivateGotWritable(slot, PROT_READ);
     if (replaced && protected_again) {
         AtomicStore(&g_native_receiver_state, uint32_t{109});
+        const uintptr_t image_base = reinterpret_cast<uintptr_t>(
+                image.dli_fbase);
+        __android_log_print(
+                ANDROID_LOG_INFO, kLogTag,
+                "resolved broadcastIntentWithFeature PLT slot dynamically "
+                "symbol_offset=0x%" PRIxPTR " slot_offset=0x%" PRIxPTR,
+                reinterpret_cast<uintptr_t>(resolved) - image_base,
+                reinterpret_cast<uintptr_t>(slot) - image_base);
         return true;
     }
 
@@ -1932,10 +1935,15 @@ void TryInstallArbiterBridge() {
     void* broadcast_send = resolver == nullptr ? nullptr
             : LookupNativeSymbol(resolver, kBroadcastSendSymbol, false,
                                  &send_size);
-    if (resolver != nullptr) FreeNativeSymbolResolver(resolver);
+    void* broadcast_image_base = resolver == nullptr ? nullptr
+            : GetNativeBaseAddress(resolver);
+    void** broadcast_intent_with_feature_slot = resolver == nullptr ? nullptr
+            : LookupNativePltSlot(resolver,
+                                  kBroadcastIntentWithFeatureSymbol);
     if (receiver_on_receive == nullptr || broadcast_intent_with_feature == nullptr ||
             broadcast_send == nullptr || receiver_size == 0u ||
             broadcast_size == 0u || send_size == 0u) {
+        if (resolver != nullptr) FreeNativeSymbolResolver(resolver);
         // The broadcast dylib is not a guaranteed dependency at launcher
         // entry. HookDlopen/HookDlsym will retry after later native loading.
         AtomicStore(&g_native_receiver_state, uint32_t{98});
@@ -1945,9 +1953,13 @@ void TryInstallArbiterBridge() {
     // Installation is process-local. A normal MiuiHome replacement forked by
     // the same injected spawner must install its own bridge; the atomic state
     // above already prevents duplicate mutation inside one process. Exact
-    // Exact process, resolved image and symbol address, GOT address/value, and
+    // process, resolved image and symbol address, GOT address/value, and
     // the launcher profile's code fingerprints remain the fail-closed guards.
-    if (!InstallBroadcastIntentWithFeatureGot(broadcast_intent_with_feature)) {
+    const bool broadcast_got_installed = InstallBroadcastIntentWithFeatureGot(
+            broadcast_intent_with_feature, broadcast_image_base,
+            broadcast_intent_with_feature_slot);
+    FreeNativeSymbolResolver(resolver);
+    if (!broadcast_got_installed) {
         AtomicStore(&g_arbiter_bridge_hook_state,
                 AtomicLoad(&g_native_receiver_state) == uint32_t{102}
                         ? uint32_t{2} : uint32_t{4});
@@ -2588,8 +2600,16 @@ const miui_home_profiles::LauncherProfile* ResolveDartFeatureProfile(
                 &g_dart_profile_resolve_state,
                 static_cast<uint32_t>(g_dart_profile_diagnostics.stage),
                 __ATOMIC_RELEASE);
-        Log(ANDROID_LOG_WARN,
-            "mapped Dart AOT feature family was absent or ambiguous");
+        __android_log_print(
+                ANDROID_LOG_WARN, kLogTag,
+                "mapped Dart AOT feature family was absent or ambiguous "
+                "stage=%u drawer=%u transition=%u overview=%u/%u editing=%u",
+                static_cast<uint32_t>(g_dart_profile_diagnostics.stage),
+                g_dart_profile_diagnostics.drawer_candidate_count,
+                g_dart_profile_diagnostics.transition_candidate_count,
+                g_dart_profile_diagnostics.overview_enter_candidate_count,
+                g_dart_profile_diagnostics.overview_exit_candidate_count,
+                g_dart_profile_diagnostics.editing_candidate_count);
         return nullptr;
     }
     AtomicStore(&g_resolved_dart_profile,
@@ -2606,8 +2626,22 @@ const miui_home_profiles::LauncherProfile* ResolveDartFeatureProfile(
                      __ATOMIC_RELEASE);
     __atomic_store_n(&g_editing_state_hook_state, uint32_t{1},
                      __ATOMIC_RELEASE);
-    Log(ANDROID_LOG_INFO,
-        "uniquely resolved mapped Dart drawer, Overview, and editing family");
+    __android_log_print(
+            ANDROID_LOG_INFO, kLogTag,
+            "resolved mapped Dart drawer, Overview, and editing family "
+            "candidates=%u/%u/%u/%u/%u offsets=0x%" PRIxPTR
+            "/0x%" PRIxPTR "/0x%" PRIxPTR "/0x%" PRIxPTR
+            "/0x%" PRIxPTR,
+            g_dart_profile_diagnostics.drawer_candidate_count,
+            g_dart_profile_diagnostics.transition_candidate_count,
+            g_dart_profile_diagnostics.overview_enter_candidate_count,
+            g_dart_profile_diagnostics.overview_exit_candidate_count,
+            g_dart_profile_diagnostics.editing_candidate_count,
+            g_dart_profile_diagnostics.drawer_progress_end_offset,
+            g_dart_profile_diagnostics.drawer_transition_complete_offset,
+            g_dart_profile_diagnostics.overview_enter_offset,
+            g_dart_profile_diagnostics.overview_exit_offset,
+            g_dart_profile_diagnostics.editing_query_offset);
     return &g_dart_profile_storage.profile;
 }
 

--- a/miui-home-hyos-native/safe_lsposed_native_deploy.py
+++ b/miui-home-hyos-native/safe_lsposed_native_deploy.py
@@ -232,6 +232,20 @@ done
         ).text.strip()
         return int(text) if re.fullmatch(r"\d+", text) else None
 
+    def wait_for_device_connection(self, timeout_seconds: float = 90.0) -> None:
+        deadline = time.monotonic() + timeout_seconds
+        last_state = ""
+        while time.monotonic() < deadline:
+            state = self.invoke_adb(["get-state"], allow_failure=True)
+            last_state = state.text.strip()
+            if state.exit_code == 0 and last_state == "device":
+                return
+            time.sleep(0.25)
+        raise RuntimeError(
+            "ADB did not reconnect within the bounded post-install window. "
+            f"Last state: {last_state or 'unavailable'}"
+        )
+
     def get_installed_apk_path(self) -> str | None:
         result = self.invoke_adb(
             ["shell", "pm", "path", PACKAGE_NAME], allow_failure=True
@@ -308,10 +322,20 @@ echo "$size"
         self, expected_systemui_pid: int, log_before: LogSnapshot
     ) -> str:
         for _ in range(100):
-            if self.get_systemui_pid() != expected_systemui_pid:
+            current_systemui_pid = self.get_systemui_pid()
+            if current_systemui_pid is None:
+                # Some devices briefly restart adbd after PackageManager
+                # replaces a debuggable APK. An unreadable PID is not evidence
+                # that SystemUI restarted: wait for the same serialized device
+                # to return, then compare the actual process identity.
+                self.wait_for_device_connection()
+                current_systemui_pid = self.get_systemui_pid()
+            if current_systemui_pid != expected_systemui_pid:
                 raise RuntimeError(
                     "SystemUI restarted during installation; API-102 hot reload was "
-                    "not preserved."
+                    "not preserved. "
+                    f"Expected PID {expected_systemui_pid}, got "
+                    f"{current_systemui_pid or 'unavailable'}."
                 )
             delta = self.read_lsposed_log_delta(log_before)
             if re.search(r"Hot reloaded, build=.*process=com\.android\.systemui", delta):
@@ -461,36 +485,44 @@ echo "$size"
 
         status_component = f"{PACKAGE_NAME}/.activity.PredictiveBackSettingsActivity"
         last_native_status = ""
-        status_log_before = self.get_lsposed_log_snapshot()
         try:
-            start = self.invoke_adb(
-                ["shell", "am", "start", "-S", "-W", "-n", status_component],
-                allow_failure=True,
-            )
-            if start.exit_code != 0 or not re.search(r"Status:\s+ok", start.text):
-                raise RuntimeError(
-                    f"Could not start the authenticated native status probe.\n{start.text}"
+            # The first authenticated query can race the private broadcast
+            # runtime-holder capture immediately after a fresh launcher fork.
+            # Retry with a new Activity instance and nonce; every attempt still
+            # requires an authenticated native response and full ready state.
+            for probe_attempt in range(3):
+                status_log_before = self.get_lsposed_log_snapshot()
+                start = self.invoke_adb(
+                    ["shell", "am", "start", "-S", "-W", "-n", status_component],
+                    allow_failure=True,
                 )
-            for _ in range(20):
-                time.sleep(0.25)
-                status_log = self.read_lsposed_log_delta(status_log_before)
-                lines = [
-                    line
-                    for line in status_log.splitlines()
-                    if "Published module runtime status reply" in line
-                    and "nativeResponse=true" in line
-                ]
-                native_status = lines[-1] if lines else ""
-                if native_status:
-                    last_native_status = native_status
-                if "statusReady=true" in native_status:
-                    return f"authenticated_native_status=ready\n{native_status}"
-                if "statusReady=false" in native_status:
+                if start.exit_code != 0 or not re.search(r"Status:\s+ok", start.text):
                     raise RuntimeError(
-                        f"Authenticated native status reported not ready.\n{native_status}"
+                        "Could not start the authenticated native status probe "
+                        f"attempt {probe_attempt + 1}.\n{start.text}"
                     )
+                for _ in range(20):
+                    time.sleep(0.25)
+                    status_log = self.read_lsposed_log_delta(status_log_before)
+                    lines = [
+                        line
+                        for line in status_log.splitlines()
+                        if "Published module runtime status reply" in line
+                        and "nativeResponse=true" in line
+                    ]
+                    native_status = lines[-1] if lines else ""
+                    if native_status:
+                        last_native_status = native_status
+                    if "statusReady=true" in native_status:
+                        return f"authenticated_native_status=ready\n{native_status}"
+                    if "statusReady=false" in native_status:
+                        raise RuntimeError(
+                            "Authenticated native status reported not ready.\n"
+                            f"{native_status}"
+                        )
             raise RuntimeError(
-                "Authenticated native status did not become ready.\n"
+                "Authenticated native status did not become ready after "
+                "3 bounded probes.\n"
                 f"{last_native_status}"
             )
         finally:
@@ -800,6 +832,7 @@ done
 
             self.install_apk(deployment_apk, enable_rollback=True)
             mutation_started = True
+            self.wait_for_device_connection()
             installed_path = self.get_installed_apk_path()
             if not installed_path:
                 raise RuntimeError(

--- a/miui-home-hyos-native/verify-launcher-profiles.py
+++ b/miui-home-hyos-native/verify-launcher-profiles.py
@@ -186,17 +186,19 @@ def resolve_dart_runtime_profile(
         publish = bl_target(rva + 96, code[24])
         if (
             state is not None and argument is not None and shared is not None
-            and argument + 8 == shared
             and code[7:10] == [0xF9402370, 0x6B10001F, 0x54000061]
             and bl_target(rva + 44, code[11]) == unbox
             and code[14:16] == [0xF90001F0, 0xF9402B64]
             and code[17:19] == [0xAA0003E1, 0xF85F83A2]
-            and code[23] == 0xF9438364
+            and (
+                (argument + 8 == shared and code[23] == 0xF9438364)
+                or code[23] & 0xFFC003FF == 0xF9400364
+            )
             and code[25:29] == [0xAA1603E0, 0xAA1D03EF,
                                 0xA8C179FD, 0xD65F03C0]
             and prepare is not None and publish is not None
         ):
-            enters.append((rva, state, shared, prepare, publish))
+            enters.append((rva, state, argument, shared, prepare, publish))
 
     exits = []
     exit_prefix = (0xA9BF79FD, 0xAA0F03FD, 0xD10041EF)
@@ -208,34 +210,64 @@ def resolve_dart_runtime_profile(
         if (
             code[3:6] == [0xB8413080, 0xB841F081, 0x8B1C8021]
             and state is not None and shared is not None
-            and code[20] == 0xF9403F40
             and code[22:25] == [0xF9402370, 0x6B10001F, 0x54000061]
-            and bl_target(rva + 104, code[26]) == unbox
+            and bl_target(rva + 104, code[26]) in (unbox, unbox - 0x3C)
             and code[29:31] == [0xF90001F0, 0xF9402B64]
-            and code[32:34] == [0xAA0003E1, 0xF85F83A5]
-            and code[38] == 0xF9438364
+            and code[32] == 0xAA0003E1
+            and code[33] & 0xFFFFFFE0 == 0xF85F83A0
+            and code[38] & 0xFFC003FF == 0xF9400364
             and code[40:44] == [0xAA1603E0, 0xAA1D03EF,
                                 0xA8C179FD, 0xD65F03C0]
             and prepare is not None and publish is not None
         ):
             exits.append((rva, state, shared, prepare, publish))
-    if len(enters) != 1 or len(exits) != 1 or enters[0][1:] != exits[0][1:]:
-        raise ValueError(
-            "Dart resolver Overview candidates/relationship: "
-            f"enter={len(enters)} exit={len(exits)}"
+
+    def same_family(enter, exit_):
+        return (
+            enter[1] != 0
+            and enter[1] == exit_[1]
+            and enter[3] != 0
+            and enter[3:] == exit_[2:]
         )
 
+    selected = []
+    if (
+        len(enters) == 1
+        and len(exits) == 1
+        and same_family(enters[0], exits[0])
+    ):
+        selected.append((enters[0], exits[0]))
+    else:
+        for enter in enters:
+            for exit_ in exits:
+                if not same_family(enter, exit_) or enter[2] < 8:
+                    continue
+                lower_siblings = sum(
+                    1
+                    for sibling in enters
+                    if sibling != enter
+                    and same_family(sibling, exit_)
+                    and sibling[2] + 8 == enter[2]
+                )
+                if lower_siblings == 1:
+                    selected.append((enter, exit_))
+    if len(selected) != 1:
+        raise ValueError(
+            "Dart resolver Overview candidates/relationship: "
+            f"enter={len(enters)} exit={len(exits)} selected={len(selected)}"
+        )
+    selected_enter, selected_exit = selected[0]
+
     editing_queries = []
-    query_prefix = (0xA9BF79FD, 0xAA0F03FD, 0xD10041EF, 0xF81F83A1,
-                    0xF9403F40, 0xF95AE800, 0x6B16001F, 0x540001A1,
-                    0xF9403F40, 0xF94D9400, 0xF9402370, 0x6B10001F,
-                    0x54000061)
+    query_prefix = (0xA9BF79FD, 0xAA0F03FD, 0xD10041EF, 0xF81F83A1)
     for query_rva, query_code in candidates(query_prefix, 16):
         if (
-            query_code[13] & 0xFFC003FF == 0xF9400362
-            and
-            bl_target(query_rva + 14 * 4, query_code[14]) is not None
-            and query_code[15] == 0x91403B70
+            query_code[4] & 0xFFC00000 == 0xF9400000
+            and query_code[6:9] == [0x6B16001F, 0x540001A1, 0xF9403F40]
+            and query_code[9] & 0xFFC00000 == 0xF9400000
+            and query_code[10:13]
+            == [0xF9402370, 0x6B10001F, 0x54000061]
+            and bl_target(query_rva + 14 * 4, query_code[14]) is not None
         ):
             editing_queries.append(query_rva)
 
@@ -278,8 +310,8 @@ def resolve_dart_runtime_profile(
         "transition_complete_offset": transition[0],
         "all_apps_state_slot_offset": all_apps,
         "home_state_slot_offset": home,
-        "overview_enter_offset": enters[0][0],
-        "overview_exit_offset": exits[0][0],
+        "overview_enter_offset": selected_enter[0],
+        "overview_exit_offset": selected_exit[0],
         "editing_query_offset": editing_query,
         "editing_query_return_offset_a": editing_return_a,
         "editing_query_return_offset_b": editing_return_b,
@@ -452,9 +484,27 @@ def main() -> None:
         default=[],
         metavar="PROFILE_ID=PATH",
     )
+    parser.add_argument(
+        "--resolve-dart-library",
+        action="append",
+        default=[],
+        type=Path,
+        metavar="PATH",
+        help=(
+            "resolve and print an arbitrary mapped-Dart ELF without a "
+            "manifest binding"
+        ),
+    )
     args = parser.parse_args()
-    if not args.library and not args.dart_library:
-        parser.error("at least one --library or --dart-library binding is required")
+    if (
+        not args.library
+        and not args.dart_library
+        and not args.resolve_dart_library
+    ):
+        parser.error(
+            "at least one --library, --dart-library, or "
+            "--resolve-dart-library input is required"
+        )
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
     profiles = {profile["id"]: profile for profile in manifest["profiles"]}
     profile_references = {
@@ -485,6 +535,15 @@ def main() -> None:
             profile_references[profile_id],
             dart_references[profile_id],
             Path(raw_path),
+        )
+    for path in args.resolve_dart_library:
+        image = path.read_bytes()
+        resolved = resolve_dart_runtime_profile(image, load_segments(image))
+        print(
+            json.dumps(
+                {"library": str(path), "resolved": resolved},
+                sort_keys=True,
+            )
         )
 
 


### PR DESCRIPTION
## Summary

- resolve the broadcastIntentWithFeature PLT slot from the exact R_AARCH64_JUMP_SLOT relocation instead of build-specific symbol and GOT offsets
- disambiguate mapped-Dart Overview enter/exit callbacks through shared function-family and adjacent pool-object relationships, covering launcher builds 6144 and 6145
- harden rebootless LSPosed deployment against the initial authenticated-status race and temporary ADB disconnects while preserving the SystemUI PID guard
- document the dynamic resolver behavior and extend the offline verifier for arbitrary mapped-Dart ELFs

## Validation

- .\gradlew.bat clean :app:testDebugUnitTest :app:assembleDebug
- python -m py_compile miui-home-hyos-native/verify-launcher-profiles.py miui-home-hyos-native/safe_lsposed_native_deploy.py
- resolved extracted launcher 6144 libapp.so to Overview enter 0x16c543c and exit 0xdb8a70
- resolved extracted launcher 6145 libapp.so to Overview enter 0x16c1b94 and exit 0xdbb0c0
- deployed launcher 801026145 with the guarded rebootless workflow; authenticated status reached statusReady=true, profileResolved=true, nativeReady=true, and bridge/business state 3 without changing the SystemUI PID or producing a new tombstone

## Scope

No Gradle, CMake, NDK/ABI, signing, or other local-only build configuration changes are included.