### PR TITLE
fix: harden Dart state hooks across launcher remaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cxx/
 .kotlin/
 .idea/
+.DS_Store
 .tmp-api/
 build/
 local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,7 @@ android {
         minSdk = 36
         targetSdk = 37
         versionCode = gitVersionCode.get()
-        versionName = "0.11.7"
+        versionName = "0.11.8"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
@@ -348,6 +348,8 @@ public abstract class HookRuntimeCore extends XposedModule {
     protected static final String EXTRA_INPUT_ARBITER_READY = "input_arbiter_ready";
     protected static final String EXTRA_INPUT_ARBITER_GENERATION =
             "input_arbiter_generation";
+    protected static final String EXTRA_LAUNCHER_STATE_OWNER_EPOCH =
+            "launcher_state_owner_epoch";
     protected static final String EXTRA_CONTEXTUAL_SEARCH_ENABLED =
             "contextual_search_enabled";
     protected static final String EXTRA_INPUT_ACCEPTED = "input_accepted";
@@ -525,6 +527,7 @@ public abstract class HookRuntimeCore extends XposedModule {
     protected volatile boolean miuiDrawerVisible;
     protected volatile boolean miuiFolderVisible;
     protected volatile boolean miuiLauncherEditing;
+    protected volatile long miuiLauncherDartStateOwnerEpoch;
     protected volatile boolean miuiLauncherXiaoAiVisible;
     protected volatile boolean miuiHomeEditingStatePublished;
     protected volatile boolean miuiLauncherOpenActive;
@@ -1216,6 +1219,7 @@ public abstract class HookRuntimeCore extends XposedModule {
         public final int displayId;
         public final int edge;
         public final long generation;
+        public final long launcherStateOwnerEpoch;
         public final long receivedUptime;
         public final long miuiHomeOpenBreakGenerationAtDown;
         public final Object miuiHomeOpenBreakAnimationAtDown;
@@ -1224,12 +1228,30 @@ public abstract class HookRuntimeCore extends XposedModule {
                                           int source, int displayId, int edge,
                                           long generation) {
             this(eventId, downTime, deviceId, source, displayId, edge,
-                    generation, 0L, null);
+                    generation, 0L, 0L, null);
+        }
+
+        public MiuiHomeAcceptedInputToken(int eventId, long downTime, int deviceId,
+                                          int source, int displayId, int edge,
+                                          long generation,
+                                          long launcherStateOwnerEpoch) {
+            this(eventId, downTime, deviceId, source, displayId, edge,
+                    generation, launcherStateOwnerEpoch, 0L, null);
         }
 
         public MiuiHomeAcceptedInputToken(int eventId, long downTime, int deviceId,
                                           int source, int displayId, int edge,
                                           long generation, long openBreakGeneration,
+                                          Object openBreakAnimation) {
+            this(eventId, downTime, deviceId, source, displayId, edge,
+                    generation, 0L, openBreakGeneration, openBreakAnimation);
+        }
+
+        public MiuiHomeAcceptedInputToken(int eventId, long downTime, int deviceId,
+                                          int source, int displayId, int edge,
+                                          long generation,
+                                          long launcherStateOwnerEpoch,
+                                          long openBreakGeneration,
                                           Object openBreakAnimation) {
             this.eventId = eventId;
             this.downTime = downTime;
@@ -1238,6 +1260,7 @@ public abstract class HookRuntimeCore extends XposedModule {
             this.displayId = displayId;
             this.edge = edge;
             this.generation = generation;
+            this.launcherStateOwnerEpoch = launcherStateOwnerEpoch;
             this.receivedUptime = SystemClock.uptimeMillis();
             this.miuiHomeOpenBreakGenerationAtDown = openBreakGeneration;
             this.miuiHomeOpenBreakAnimationAtDown = openBreakAnimation;

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/hotreload/HotReloadHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/hotreload/HotReloadHookRuntime.java
@@ -81,6 +81,8 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
         boolean savedMiuiDrawerVisible = miuiDrawerVisible;
         boolean savedMiuiFolderVisible = miuiFolderVisible;
         boolean savedMiuiLauncherEditing = miuiLauncherEditing;
+        long savedMiuiLauncherDartStateOwnerEpoch =
+                miuiLauncherDartStateOwnerEpoch;
         long savedMiuiOverviewDismissDeadline = miuiOverviewDismissPendingUntilUptime;
         Object savedMiuiHomeOpenBreakController = miuiHomeOpenBreakController;
         Context savedMiuiHomeOpenBreakContext = miuiHomeOpenBreakContext;
@@ -165,7 +167,8 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
                 savedHeadlessState,
                 Boolean.valueOf(savedMiuiLauncherEditing),
                 Boolean.valueOf(savedMiuiFolderVisible),
-                savedContextualSearchNavigationBars
+                savedContextualSearchNavigationBars,
+                Long.valueOf(savedMiuiLauncherDartStateOwnerEpoch)
         });
         return true;
     }
@@ -1050,6 +1053,10 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
                 }
                 if (state.length >= 16 && state[15] instanceof Object[]) {
                     pendingHotReloadContextualSearchNavigationBars = (Object[]) state[15];
+                }
+                if (state.length >= 17 && state[16] instanceof Long) {
+                    miuiLauncherDartStateOwnerEpoch =
+                            ((Long) state[16]).longValue();
                 }
             }
         }

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiHookRuntime.java
@@ -6279,6 +6279,47 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
                             "miuiHomeQuery");
                     return;
                 }
+                boolean carriesDartState = intent.hasExtra("drawer_visible")
+                        || intent.hasExtra("overview_visible")
+                        || intent.hasExtra(EXTRA_LAUNCHER_EDITING);
+                if (Build.VERSION.SDK_INT >= ANDROID_17_API_LEVEL
+                        && (carriesDartState
+                        || intent.hasExtra(EXTRA_LAUNCHER_STATE_OWNER_EPOCH))) {
+                    long ownerEpoch = intent.getLongExtra(
+                            EXTRA_LAUNCHER_STATE_OWNER_EPOCH, 0L);
+                    long ownerGeneration = intent.getLongExtra(
+                            EXTRA_INPUT_ARBITER_GENERATION, 0L);
+                    if (ownerEpoch <= 0L
+                            || ownerGeneration != systemUiInputArbiterGeneration) {
+                        moduleLog(Log.WARN, TAG,
+                                "Rejected invalid native launcher-state owner"
+                                        + ", ownerEpoch=" + ownerEpoch
+                                        + ", generation=" + ownerGeneration
+                                        + ", currentGeneration="
+                                        + systemUiInputArbiterGeneration);
+                        return;
+                    }
+                    if (ownerEpoch < miuiLauncherDartStateOwnerEpoch) {
+                        moduleLog(Log.WARN, TAG,
+                                "Ignored retired native launcher-state owner"
+                                        + ", ownerEpoch=" + ownerEpoch
+                                        + ", currentOwnerEpoch="
+                                        + miuiLauncherDartStateOwnerEpoch);
+                        return;
+                    }
+                    if (ownerEpoch > miuiLauncherDartStateOwnerEpoch) {
+                        miuiLauncherDartStateOwnerEpoch = ownerEpoch;
+                        acceptedInputToken.set(null);
+                        miuiDrawerVisible = false;
+                        miuiOverviewVisible = false;
+                        miuiLauncherEditing = false;
+                        miuiOverviewDismissPendingUntilUptime = 0L;
+                        moduleLog(Log.INFO, TAG,
+                                "Adopted native launcher-state owner"
+                                        + ", ownerEpoch=" + ownerEpoch
+                                        + ", generation=" + ownerGeneration);
+                    }
+                }
                 if (intent.getBooleanExtra(EXTRA_INPUT_ACCEPTED, false)) {
                     receiveMiuiHomeAcceptedInput(intent);
                 }
@@ -6751,7 +6792,8 @@ public abstract class SystemUiHookRuntime extends SystemUiInputRuntime {
                 intent.getIntExtra(EXTRA_INPUT_DEVICE_ID, Integer.MIN_VALUE),
                 intent.getIntExtra(EXTRA_INPUT_SOURCE, 0),
                 intent.getIntExtra(EXTRA_INPUT_DISPLAY_ID, Integer.MIN_VALUE),
-                intent.getIntExtra(EXTRA_INPUT_EDGE, -1), generation);
+                intent.getIntExtra(EXTRA_INPUT_EDGE, -1), generation,
+                intent.getLongExtra(EXTRA_LAUNCHER_STATE_OWNER_EPOCH, 0L));
         if (token.downTime == Long.MIN_VALUE
                 || token.deviceId == Integer.MIN_VALUE
                 || token.displayId == Integer.MIN_VALUE

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiInputRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/systemui/SystemUiInputRuntime.java
@@ -861,6 +861,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
         protected float downX;
         protected float downY;
         protected long downTime = Long.MIN_VALUE;
+        protected long downLauncherStateOwnerEpoch;
         protected MotionEvent pendingDownEvent;
         protected MotionEvent pendingMotionEvent;
 
@@ -961,7 +962,18 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
         }
 
         protected boolean handleMotionEvent(MotionEvent event) {
-            switch (event.getActionMasked()) {
+            int action = event.getActionMasked();
+            if (action != MotionEvent.ACTION_DOWN && gestureCandidate
+                    && Build.VERSION.SDK_INT >= ANDROID_17_API_LEVEL
+                    && downLauncherStateOwnerEpoch > 0L
+                    && downLauncherStateOwnerEpoch
+                    != miuiLauncherDartStateOwnerEpoch) {
+                boolean handled = pilfered;
+                cancelNativeCandidate(event,
+                        "launcher Dart state owner changed");
+                return handled;
+            }
+            switch (action) {
                 case MotionEvent.ACTION_DOWN:
                     return onNativeDown(event);
                 case MotionEvent.ACTION_MOVE:
@@ -988,6 +1000,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             downTime = event.getDownTime();
             downDeviceId = event.getDeviceId();
             downSource = event.getSource();
+            downLauncherStateOwnerEpoch = miuiLauncherDartStateOwnerEpoch;
             try {
                 downEventId = readMotionEventId(event);
                 downDisplayId = readMotionEventDisplayId(event);
@@ -1139,6 +1152,10 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                     && gestureCandidate
                     && !miuiHomeInputAccepted
                     && token.generation == systemUiInputArbiterGeneration
+                    && (Build.VERSION.SDK_INT < ANDROID_17_API_LEVEL
+                    || (token.launcherStateOwnerEpoch > 0L
+                    && token.launcherStateOwnerEpoch
+                    == downLauncherStateOwnerEpoch))
                     && token.eventId == downEventId
                     && token.downTime == downTime
                     && token.deviceId == downDeviceId
@@ -1875,6 +1892,7 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             downX = 0.0f;
             downY = 0.0f;
             downTime = Long.MIN_VALUE;
+            downLauncherStateOwnerEpoch = 0L;
         }
 
         protected boolean isNavigationBarHidden() {
@@ -3346,6 +3364,10 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
                     && expectedInputMonitorEpoch == inputMonitorEpoch.get()
                     && expectedController == controller
                     && inputIdentity.generation == systemUiInputArbiterGeneration
+                    && (Build.VERSION.SDK_INT < ANDROID_17_API_LEVEL
+                    || (inputIdentity.launcherStateOwnerEpoch > 0L
+                    && inputIdentity.launcherStateOwnerEpoch
+                    == miuiLauncherDartStateOwnerEpoch))
                     && inputIdentity.edge == edge;
         }
 
@@ -3658,6 +3680,20 @@ public abstract class SystemUiInputRuntime extends HookRuntimeCore {
             Object releaseController = session.controller;
             Object tracker = null;
             try {
+                if (releaseAllowed && !isCurrentAcceptedInputIdentity(
+                        inputIdentity, releaseEdge, releaseController,
+                        session.inputEpoch)) {
+                    releaseAllowed = false;
+                    moduleLog(Log.WARN, TAG,
+                            "Forced Shell release cancellation after launcher "
+                                    + "state owner changed"
+                                    + ", shellSessionId=" + session.id
+                                    + ", inputOwnerEpoch="
+                                    + (inputIdentity == null ? 0L
+                                    : inputIdentity.launcherStateOwnerEpoch)
+                                    + ", currentOwnerEpoch="
+                                    + miuiLauncherDartStateOwnerEpoch);
+                }
                 if (session.moveFailed.get()) {
                     releaseAllowed = false;
                     moduleLog(Log.WARN, TAG,

--- a/miui-home-hyos-native/dart_runtime_resolver.cpp
+++ b/miui-home-hyos-native/dart_runtime_resolver.cpp
@@ -252,6 +252,98 @@ bool MatchTransition(const ElfView& view, uintptr_t offset,
             call_target == unbox_target;
 }
 
+constexpr uint32_t kDartRestoreFrame = 0xaa1d03efu;
+constexpr uint32_t kDartPopFrame = 0xa8c179fdu;
+constexpr uint32_t kDartReturn = 0xd65f03c0u;
+constexpr uint32_t kDartReturnX22 = 0xaa1603e0u;
+constexpr uint32_t kDartReturnTrue = 0x910082c0u;
+constexpr uint32_t kDartReturnFalse = 0x9100c2c0u;
+
+bool IsDartReturnEpilogue(const ElfView& view, uintptr_t offset,
+                          uint32_t first) {
+    uint32_t code[4]{};
+    return ReadInstructions(view, offset, code, 4u) && code[0] == first &&
+            code[1] == kDartRestoreFrame && code[2] == kDartPopFrame &&
+            code[3] == kDartReturn;
+}
+
+bool FindUniqueDrawerCallerEpilogue(
+        const ElfView& view, uintptr_t transition, uintptr_t* result) {
+    if (result == nullptr) return false;
+    constexpr uint32_t kCallerPrefix[] = {
+            0xa9bf79fdu, 0xaa0f03fdu, 0xf9400fa0u, 0xb8417001u,
+            0x8b1c8021u, 0xb840f020u, 0x8b1c8000u, 0xaa0003e1u,
+            0xf9400ba2u};
+    size_t direct_call_count = 0u;
+    size_t valid_caller_count = 0u;
+    uintptr_t match = 0u;
+    for (size_t segment_index = 0u; segment_index < view.load_count;
+         ++segment_index) {
+        const LoadSegment& load = view.loads[segment_index];
+        if ((load.flags & (PF_R | PF_X)) != (PF_R | PF_X)) continue;
+        for (uintptr_t cursor = (load.start + 3u) & ~uintptr_t{3u};
+             cursor < load.end && load.end - cursor >= sizeof(uint32_t);
+             cursor += 4u) {
+            uint32_t instruction = 0u;
+            uintptr_t target = 0u;
+            if (!ReadInstruction(view, cursor, &instruction) ||
+                    !DecodeBlTarget(cursor, instruction, &target) ||
+                    target != transition) {
+                continue;
+            }
+            ++direct_call_count;
+            if (cursor < sizeof(kCallerPrefix)) continue;
+            const uintptr_t caller = cursor - sizeof(kCallerPrefix);
+            uint32_t prefix[sizeof(kCallerPrefix) / sizeof(uint32_t)]{};
+            if (!ReadInstructions(
+                        view, caller, prefix,
+                        sizeof(prefix) / sizeof(prefix[0])) ||
+                    memcmp(prefix, kCallerPrefix, sizeof(prefix)) != 0 ||
+                    !IsDartReturnEpilogue(
+                            view, cursor + sizeof(uint32_t),
+                            kDartReturnX22)) {
+                continue;
+            }
+            ++valid_caller_count;
+            match = cursor + sizeof(uint32_t);
+        }
+    }
+    if (direct_call_count != 1u || valid_caller_count != 1u) return false;
+    *result = match;
+    return true;
+}
+
+bool FindUniqueDartReturnEpilogue(
+        const ElfView& view, uintptr_t start, uintptr_t span,
+        uint32_t first, uintptr_t* result) {
+    if (result == nullptr || AddOverflows(start, span)) return false;
+    uintptr_t match = 0u;
+    size_t count = 0u;
+    for (uintptr_t cursor = start; cursor < start + span; cursor += 4u) {
+        if (!IsDartReturnEpilogue(view, cursor, first)) continue;
+        match = cursor;
+        ++count;
+    }
+    if (count != 1u) return false;
+    *result = match;
+    return true;
+}
+
+size_t CollectDartReturnEpilogues(
+        const ElfView& view, uintptr_t start, uintptr_t span, uint32_t first,
+        uintptr_t* results, size_t capacity) {
+    if (results == nullptr || capacity == 0u || AddOverflows(start, span)) {
+        return 0u;
+    }
+    size_t count = 0u;
+    for (uintptr_t cursor = start; cursor < start + span; cursor += 4u) {
+        if (!IsDartReturnEpilogue(view, cursor, first)) continue;
+        if (count >= capacity) return capacity + 1u;
+        results[count++] = cursor;
+    }
+    return count;
+}
+
 bool MatchOverviewEnter(const ElfView& view, uintptr_t offset,
                         uintptr_t unbox_target,
                         OverviewCandidate* candidate) {
@@ -698,6 +790,36 @@ bool ResolveDartFeatureProfile(
         return false;
     }
 
+    uintptr_t drawer_epilogue = 0u;
+    const uintptr_t enter_epilogue = enter.offset + 25u * 4u;
+    const uintptr_t exit_epilogue = exit.offset + 40u * 4u;
+    uintptr_t editing_false_epilogue = 0u;
+    uintptr_t editing_true_epilogues[4]{};
+    uintptr_t editing_false_epilogues[4]{};
+    if (!FindUniqueDrawerCallerEpilogue(
+                view, transition_offset, &drawer_epilogue) ||
+            !FindUniqueDartReturnEpilogue(
+                    view, editing.query_offset, 0x200u,
+                    kDartReturnFalse, &editing_false_epilogue) ||
+            editing_false_epilogue <= editing.query_offset ||
+            !IsDartReturnEpilogue(
+                    view, enter_epilogue, kDartReturnX22) ||
+            !IsDartReturnEpilogue(
+                    view, exit_epilogue, kDartReturnX22)) {
+        diagnostics->stage = ResolveStage::kRejectedEditing;
+        return false;
+    }
+    const size_t editing_true_count = CollectDartReturnEpilogues(
+            view, editing.query_offset,
+            editing_false_epilogue - editing.query_offset,
+            kDartReturnTrue, editing_true_epilogues, 4u);
+    if (editing_true_count == 0u || editing_true_count > 4u) {
+        diagnostics->stage = ResolveStage::kRejectedEditing;
+        return false;
+    }
+    editing_false_epilogues[0] = editing_false_epilogue;
+    constexpr size_t editing_false_count = 1u;
+
     storage->profile = launcher_profile;
     auto& profile = storage->profile;
     profile.dart_snapshot_instructions_offset = instructions_offset;
@@ -743,6 +865,17 @@ bool ResolveDartFeatureProfile(
             sizeof(storage->editing_query_prologue);
     profile.dart_editing_query_return_offset_a = editing.return_offset_a;
     profile.dart_editing_query_return_offset_b = editing.return_offset_b;
+    profile.dart_drawer_transition_epilogue_offset = drawer_epilogue;
+    profile.dart_overview_enter_epilogue_offset = enter_epilogue;
+    profile.dart_overview_exit_epilogue_offset = exit_epilogue;
+    memcpy(profile.dart_editing_true_epilogue_offsets,
+           editing_true_epilogues,
+           editing_true_count * sizeof(editing_true_epilogues[0]));
+    profile.dart_editing_true_epilogue_count = editing_true_count;
+    memcpy(profile.dart_editing_false_epilogue_offsets,
+           editing_false_epilogues,
+           editing_false_count * sizeof(editing_false_epilogues[0]));
+    profile.dart_editing_false_epilogue_count = editing_false_count;
 
     diagnostics->drawer_progress_end_offset = drawer.offset;
     diagnostics->drawer_transition_complete_offset = transition_offset;
@@ -752,6 +885,17 @@ bool ResolveDartFeatureProfile(
     diagnostics->editing_query_offset = editing.query_offset;
     diagnostics->editing_query_return_offset_a = editing.return_offset_a;
     diagnostics->editing_query_return_offset_b = editing.return_offset_b;
+    diagnostics->drawer_transition_epilogue_offset = drawer_epilogue;
+    diagnostics->overview_enter_epilogue_offset = enter_epilogue;
+    diagnostics->overview_exit_epilogue_offset = exit_epilogue;
+    memcpy(diagnostics->editing_true_epilogue_offsets,
+           editing_true_epilogues,
+           editing_true_count * sizeof(editing_true_epilogues[0]));
+    diagnostics->editing_true_epilogue_count = editing_true_count;
+    memcpy(diagnostics->editing_false_epilogue_offsets,
+           editing_false_epilogues,
+           editing_false_count * sizeof(editing_false_epilogues[0]));
+    diagnostics->editing_false_epilogue_count = editing_false_count;
     diagnostics->all_apps_state_slot_offset = drawer.all_apps_slot;
     diagnostics->home_state_slot_offset = drawer.home_slot;
     diagnostics->stage = ResolveStage::kComplete;

--- a/miui-home-hyos-native/dart_runtime_resolver.h
+++ b/miui-home-hyos-native/dart_runtime_resolver.h
@@ -43,10 +43,17 @@ struct ResolutionDiagnostics {
     uintptr_t drawer_transition_complete_offset;
     uintptr_t overview_enter_offset;
     uintptr_t overview_exit_offset;
+    uintptr_t drawer_transition_epilogue_offset;
+    uintptr_t overview_enter_epilogue_offset;
+    uintptr_t overview_exit_epilogue_offset;
     uintptr_t editing_refresh_offset;
     uintptr_t editing_query_offset;
     uintptr_t editing_query_return_offset_a;
     uintptr_t editing_query_return_offset_b;
+    uintptr_t editing_true_epilogue_offsets[4];
+    size_t editing_true_epilogue_count;
+    uintptr_t editing_false_epilogue_offsets[4];
+    size_t editing_false_epilogue_count;
     uintptr_t all_apps_state_slot_offset;
     uintptr_t home_state_slot_offset;
 };

--- a/miui-home-hyos-native/dart_state_hooks.S
+++ b/miui-home-hyos-native/dart_state_hooks.S
@@ -1,192 +1,246 @@
     .text
-    .p2align 2
-    .global MiuiHomeHyosDartDrawerTransitionCompleteHook
-    .hidden MiuiHomeHyosDartDrawerTransitionCompleteHook
-    .type MiuiHomeHyosDartDrawerTransitionCompleteHook, %function
-MiuiHomeHyosDartDrawerTransitionCompleteHook:
-    // This exact _AllAppsCategoryListPageState._onDrawerVisibilityChanged
-    // callback is the sole ALL_APPS publication owner. Its visibility
-    // argument is the Dart bool in entry x2.
-    bti c
-    sub sp, sp, #0x60
+
+    // These hooks replace exact four-instruction Dart return epilogues after
+    // Xiaomi has published its state. They never call a Dart trampoline or a
+    // C/C++ function. The observer preserves all live registers and NZCV,
+    // performs only atomic memory operations plus a raw eventfd write, then
+    // emulates the displaced epilogue and returns to the original caller.
+    .equ DART_EPILOGUE_SCRATCH_SIZE, 0x60
+
+    .macro save_epilogue_scratch
+    sub sp, sp, #DART_EPILOGUE_SCRATCH_SIZE
     stp x0, x1, [sp, #0x00]
-    stp x2, x15, [sp, #0x10]
-    stp x22, x26, [sp, #0x20]
-    stp x27, x28, [sp, #0x30]
-    str x30, [sp, #0x40]
+    stp x2, x8, [sp, #0x10]
+    stp x12, x13, [sp, #0x20]
+    stp x14, x15, [sp, #0x30]
+    stp x16, x17, [sp, #0x40]
+    mrs x17, nzcv
+    str x17, [sp, #0x50]
+    .endm
 
-    adrp x16, miui_home_hyos_dart_transition_complete_original
-    add x16, x16, :lo12:miui_home_hyos_dart_transition_complete_original
-    ldar x16, [x16]
-    blr x16
-    str x0, [sp, #0x48]
+    .macro restore_epilogue_scratch
+    ldr x17, [sp, #0x50]
+    msr nzcv, x17
+    ldp x0, x1, [sp, #0x00]
+    ldp x2, x8, [sp, #0x10]
+    ldp x12, x13, [sp, #0x20]
+    ldp x14, x15, [sp, #0x30]
+    ldp x16, x17, [sp, #0x40]
+    add sp, sp, #DART_EPILOGUE_SCRATCH_SIZE
+    .endm
 
-    ldr x2, [sp, #0x10]
-    ldr x11, [sp, #0x20]
-    add x12, x11, #0x20
-    cmp w2, w12
-    b.eq .Lcomplete_visible
+    .macro mark_dart_state_pending mask
+    adrp x16, g_dart_state_publish_pending
+    add x16, x16, :lo12:g_dart_state_publish_pending
+.Lpending_retry\@:
+    ldxr w17, [x16]
+    orr w17, w17, #\mask
+    stlxr w12, w17, [x16]
+    cbnz w12, .Lpending_retry\@
+    .endm
 
-    // Accept only the isolate's canonical false singleton. An unexpected
-    // object preserves Xiaomi's result and publishes no launcher state.
-    add x12, x11, #0x30
-    cmp w2, w12
-    b.ne .Lcomplete_restore
-    mov w0, wzr
-    b .Lcomplete_publish
+    .macro wake_dart_state_publisher
+    mov x17, #1
+    str x17, [sp, #0x58]
+    adrp x16, g_dart_state_publish_event_fd
+    add x16, x16, :lo12:g_dart_state_publish_event_fd
+    ldar w0, [x16]
+    tbnz w0, #31, .Lwake_done\@
+    add x1, sp, #0x58
+    mov x2, #8
+    mov x8, #64
+    svc #0
+.Lwake_done\@:
+    .endm
 
-.Lcomplete_visible:
-    mov w0, #1
-.Lcomplete_publish:
-    bl MiuiHomeHyosDartDrawerStateObserved
+    .macro store_dart_observation symbol, value, unchanged
+    adrp x16, g_dart_state_owner_epoch
+    add x16, x16, :lo12:g_dart_state_owner_epoch
+    ldar x13, [x16]
+    lsl x17, x13, #2
+    orr x17, x17, #\value
+    adrp x16, \symbol
+    add x16, x16, :lo12:\symbol
+.Lobservation_retry\@:
+    ldaxr x12, [x16]
+    cmp x12, x17
+    b.eq .Lobservation_unchanged\@
+    lsr x14, x12, #2
+    cmp x14, x13
+    b.hi .Lobservation_unchanged\@
+    stlxr w14, x17, [x16]
+    cbnz w14, .Lobservation_retry\@
+    b .Lobservation_stored\@
+.Lobservation_unchanged\@:
+    clrex
+    b \unchanged
+.Lobservation_stored\@:
+    .endm
 
-.Lcomplete_restore:
-    ldr x0, [sp, #0x48]
-    ldr x15, [sp, #0x18]
-    ldp x22, x26, [sp, #0x20]
-    ldp x27, x28, [sp, #0x30]
-    ldr x30, [sp, #0x40]
-    add sp, sp, #0x60
+    .macro increment_dart_counter symbol
+    adrp x16, \symbol
+    add x16, x16, :lo12:\symbol
+.Lcounter_retry\@:
+    ldxr w17, [x16]
+    add w17, w17, #1
+    stxr w12, w17, [x16]
+    cbnz w12, .Lcounter_retry\@
+    .endm
+
+    .macro enter_dart_observer counter, retiring, leave
+    adrp x16, \retiring
+    add x16, x16, :lo12:\retiring
+    adrp x13, \counter
+    add x13, x13, :lo12:\counter
+.Lactive_enter_retry\@:
+    ldaxr w17, [x13]
+    add w17, w17, #1
+    stlxr w12, w17, [x13]
+    cbnz w12, .Lactive_enter_retry\@
+    ldar w17, [x16]
+    cbnz w17, \leave
+    .endm
+
+    .macro leave_dart_observer counter
+    adrp x16, \counter
+    add x16, x16, :lo12:\counter
+.Lactive_leave_retry\@:
+    ldaxr w17, [x16]
+    cbz w17, .Lactive_leave_zero\@
+    sub w17, w17, #1
+    stlxr w12, w17, [x16]
+    cbnz w12, .Lactive_leave_retry\@
+    b .Lactive_leave_done\@
+.Lactive_leave_zero\@:
+    clrex
+.Lactive_leave_done\@:
+    .endm
+
+    .macro finish_return_x22
+    restore_epilogue_scratch
+    mov x0, x22
+    mov x15, x29
+    ldp x29, x30, [x15], #16
     ret
-    .size MiuiHomeHyosDartDrawerTransitionCompleteHook, .-MiuiHomeHyosDartDrawerTransitionCompleteHook
+    .endm
 
     .p2align 2
-    .global MiuiHomeHyosDartOverviewEnterHook
-    .hidden MiuiHomeHyosDartOverviewEnterHook
-    .type MiuiHomeHyosDartOverviewEnterHook, %function
-MiuiHomeHyosDartOverviewEnterHook:
-    // sendEnterOverviewSignal is the Flutter owner's accepted transition
-    // boundary. Preserve Dart's fixed registers while the C++ observer mirrors
-    // the state only after Xiaomi has emitted its own signal.
+    .global MiuiHomeHyosDartDrawerTransitionEpilogueHook
+    .hidden MiuiHomeHyosDartDrawerTransitionEpilogueHook
+    .type MiuiHomeHyosDartDrawerTransitionEpilogueHook, %function
+MiuiHomeHyosDartDrawerTransitionEpilogueHook:
     bti c
-    sub sp, sp, #0x60
-    stp x0, x1, [sp, #0x00]
-    stp x2, x15, [sp, #0x10]
-    stp x22, x26, [sp, #0x20]
-    stp x27, x28, [sp, #0x30]
-    str x30, [sp, #0x40]
-
-    adrp x16, miui_home_hyos_dart_overview_enter_original
-    add x16, x16, :lo12:miui_home_hyos_dart_overview_enter_original
-    ldar x16, [x16]
-    blr x16
-    str x0, [sp, #0x48]
-
-    mov w0, #1
-    bl MiuiHomeHyosDartOverviewStateObserved
-
-    ldr x0, [sp, #0x48]
-    ldr x15, [sp, #0x18]
-    ldp x22, x26, [sp, #0x20]
-    ldp x27, x28, [sp, #0x30]
-    ldr x30, [sp, #0x40]
-    add sp, sp, #0x60
+    save_epilogue_scratch
+    enter_dart_observer g_dart_drawer_active_count, g_dart_drawer_retiring, .Ldrawer_leave
+    // The original Dart frame still owns the visibility argument at x29+16.
+    ldr x12, [x29, #0x10]
+    add x13, x22, #0x20
+    cmp x12, x13
+    b.eq .Ldrawer_visible
+    add x13, x22, #0x30
+    cmp x12, x13
+    b.ne .Ldrawer_leave
+    store_dart_observation g_drawer_state_observation, 1, .Ldrawer_leave
+    mark_dart_state_pending 1
+    b .Ldrawer_wake
+.Ldrawer_visible:
+    store_dart_observation g_drawer_state_observation, 2, .Ldrawer_leave
+    mark_dart_state_pending 1
+.Ldrawer_wake:
+    wake_dart_state_publisher
+.Ldrawer_leave:
+    leave_dart_observer g_dart_drawer_active_count
+    restore_epilogue_scratch
+    mov x0, x22
+    mov x15, x29
+    ldp x29, x30, [x15], #16
     ret
-    .size MiuiHomeHyosDartOverviewEnterHook, .-MiuiHomeHyosDartOverviewEnterHook
+    .size MiuiHomeHyosDartDrawerTransitionEpilogueHook, .-MiuiHomeHyosDartDrawerTransitionEpilogueHook
 
     .p2align 2
-    .global MiuiHomeHyosDartOverviewExitHook
-    .hidden MiuiHomeHyosDartOverviewExitHook
-    .type MiuiHomeHyosDartOverviewExitHook, %function
-MiuiHomeHyosDartOverviewExitHook:
-    // sendExitOverviewSignal is shared by every native Flutter Overview exit.
+    .global MiuiHomeHyosDartOverviewEnterEpilogueHook
+    .hidden MiuiHomeHyosDartOverviewEnterEpilogueHook
+    .type MiuiHomeHyosDartOverviewEnterEpilogueHook, %function
+MiuiHomeHyosDartOverviewEnterEpilogueHook:
     bti c
-    sub sp, sp, #0x60
-    stp x0, x1, [sp, #0x00]
-    stp x2, x15, [sp, #0x10]
-    stp x22, x26, [sp, #0x20]
-    stp x27, x28, [sp, #0x30]
-    str x30, [sp, #0x40]
-
-    adrp x16, miui_home_hyos_dart_overview_exit_original
-    add x16, x16, :lo12:miui_home_hyos_dart_overview_exit_original
-    ldar x16, [x16]
-    blr x16
-    str x0, [sp, #0x48]
-
-    mov w0, wzr
-    bl MiuiHomeHyosDartOverviewStateObserved
-
-    ldr x0, [sp, #0x48]
-    ldr x15, [sp, #0x18]
-    ldp x22, x26, [sp, #0x20]
-    ldp x27, x28, [sp, #0x30]
-    ldr x30, [sp, #0x40]
-    add sp, sp, #0x60
-    ret
-    .size MiuiHomeHyosDartOverviewExitHook, .-MiuiHomeHyosDartOverviewExitHook
+    save_epilogue_scratch
+    enter_dart_observer g_dart_overview_enter_active_count, g_dart_overview_enter_retiring, .Loverview_enter_leave
+    increment_dart_counter g_overview_dart_enter_count
+    store_dart_observation g_overview_state_observation, 2, .Loverview_enter_leave
+    mark_dart_state_pending 2
+    wake_dart_state_publisher
+.Loverview_enter_leave:
+    leave_dart_observer g_dart_overview_enter_active_count
+    finish_return_x22
+    .size MiuiHomeHyosDartOverviewEnterEpilogueHook, .-MiuiHomeHyosDartOverviewEnterEpilogueHook
 
     .p2align 2
-    .global MiuiHomeHyosDartEditingQueryHook
-    .hidden MiuiHomeHyosDartEditingQueryHook
-    .type MiuiHomeHyosDartEditingQueryHook, %function
-MiuiHomeHyosDartEditingQueryHook:
-    // EditModeGetxController.isNeedEnableSystemBack is shared. Observe it only
-    // for the two call sites inside LauncherOverlayStateManager's uniquely
-    // resolved back-status refresh; every other caller stays invisible.
+    .global MiuiHomeHyosDartOverviewExitEpilogueHook
+    .hidden MiuiHomeHyosDartOverviewExitEpilogueHook
+    .type MiuiHomeHyosDartOverviewExitEpilogueHook, %function
+MiuiHomeHyosDartOverviewExitEpilogueHook:
     bti c
-    sub sp, sp, #0x60
-    stp x0, x1, [sp, #0x00]
-    stp x2, x15, [sp, #0x10]
-    stp x22, x26, [sp, #0x20]
-    stp x27, x28, [sp, #0x30]
-    str x30, [sp, #0x40]
+    save_epilogue_scratch
+    enter_dart_observer g_dart_overview_exit_active_count, g_dart_overview_exit_retiring, .Loverview_exit_leave
+    increment_dart_counter g_overview_dart_exit_count
+    store_dart_observation g_overview_state_observation, 1, .Loverview_exit_leave
+    mark_dart_state_pending 2
+    wake_dart_state_publisher
+.Loverview_exit_leave:
+    leave_dart_observer g_dart_overview_exit_active_count
+    finish_return_x22
+    .size MiuiHomeHyosDartOverviewExitEpilogueHook, .-MiuiHomeHyosDartOverviewExitEpilogueHook
 
-    adrp x16, miui_home_hyos_dart_editing_query_original
-    add x16, x16, :lo12:miui_home_hyos_dart_editing_query_original
-    ldar x16, [x16]
-    blr x16
-    str x0, [sp, #0x48]
-
-    ldr x11, [sp, #0x40]
+    .macro editing_epilogue_hook name, value, return_offset
+    .p2align 2
+    .global \name
+    .hidden \name
+    .type \name, %function
+\name:
+    bti c
+    save_epilogue_scratch
+    enter_dart_observer g_dart_editing_active_count, g_dart_editing_retiring, .Lediting_leave\@
+    // x29 still identifies the original Dart frame. Publish only for the two
+    // proven Launcher callers saved in that frame's LR slot.
+    ldr x12, [x29, #8]
     adrp x16, miui_home_hyos_dart_editing_return_a
     add x16, x16, :lo12:miui_home_hyos_dart_editing_return_a
-    ldar x12, [x16]
-    cmp x11, x12
-    b.eq .Lediting_validate
+    ldar x13, [x16]
+    cmp x12, x13
+    b.eq .Lediting_publish\@
     adrp x16, miui_home_hyos_dart_editing_return_b
     add x16, x16, :lo12:miui_home_hyos_dart_editing_return_b
-    ldar x12, [x16]
-    cmp x11, x12
-    b.ne .Lediting_restore
-
-.Lediting_validate:
-    ldr x11, [sp, #0x20]
-    ldr x12, [sp, #0x48]
-    add x13, x11, #0x20
-    cmp w12, w13
-    b.eq .Lediting_true
-    add x13, x11, #0x30
-    cmp w12, w13
-    b.ne .Lediting_restore
-    mov w0, wzr
-    b .Lediting_publish
-
-.Lediting_true:
-    mov w0, #1
-.Lediting_publish:
-    bl MiuiHomeHyosDartEditingStateObserved
-
-.Lediting_restore:
-    ldr x0, [sp, #0x48]
-    ldr x15, [sp, #0x18]
-    ldp x22, x26, [sp, #0x20]
-    ldp x27, x28, [sp, #0x30]
-    ldr x30, [sp, #0x40]
-    add sp, sp, #0x60
+    ldar x13, [x16]
+    cmp x12, x13
+    b.ne .Lediting_leave\@
+.Lediting_publish\@:
+    increment_dart_counter g_editing_dart_observe_count
+    store_dart_observation g_editing_state_observation, \value, .Lediting_leave\@
+    mark_dart_state_pending 4
+    wake_dart_state_publisher
+.Lediting_leave\@:
+    leave_dart_observer g_dart_editing_active_count
+    restore_epilogue_scratch
+    add x0, x22, #\return_offset
+    mov x15, x29
+    ldp x29, x30, [x15], #16
     ret
-    .size MiuiHomeHyosDartEditingQueryHook, .-MiuiHomeHyosDartEditingQueryHook
+    .size \name, .-\name
+    .endm
 
-    // Match the C++ object's BTI/PAC/GCS GNU property declaration.
-    .section .note.gnu.property,"a",%note
+    editing_epilogue_hook MiuiHomeHyosDartEditingFalseEpilogueHook, 1, 0x30
+    editing_epilogue_hook MiuiHomeHyosDartEditingTrueEpilogueHook, 2, 0x20
+
+    .section .note.gnu.property, "a"
     .p2align 3
     .long 4
     .long 16
     .long 5
     .asciz "GNU"
+    .p2align 3
     .long 0xc0000000
     .long 4
-    .long 7
+    .long 1
     .long 0
 
     .section .note.GNU-stack,"",%progbits

--- a/miui-home-hyos-native/generate-launcher-profiles.py
+++ b/miui-home-hyos-native/generate-launcher-profiles.py
@@ -251,6 +251,14 @@ def generate(manifest: dict) -> str:
                 f"        {hex_literal(abi.get('runtime_pointer_offset'))},",
                 f"        {hex_literal(abi.get('runtime_state_offset'))},",
                 f"        {ready_value}u,",
+                # Runtime Dart resolver fills these exact return epilogues.
+                "        0u,",
+                "        0u,",
+                "        0u,",
+                "        {},",
+                "        0u,",
+                "        {},",
+                "        0u,",
                 "};",
                 "",
             )

--- a/miui-home-hyos-native/generated/launcher_profiles.generated.h
+++ b/miui-home-hyos-native/generated/launcher_profiles.generated.h
@@ -99,6 +99,13 @@ inline constexpr LauncherProfile kProfile6144 = {
         0xe77338u,
         0xe77340u,
         3u,
+        0u,
+        0u,
+        0u,
+        {},
+        0u,
+        {},
+        0u,
 };
 
 inline constexpr uint8_t kIdentity4371AcceptedPilferCall0[] = {
@@ -204,6 +211,13 @@ inline constexpr LauncherProfile kProfile4371 = {
         0x13cd7e8u,
         0x13cd7f0u,
         3u,
+        0u,
+        0u,
+        0u,
+        {},
+        0u,
+        {},
+        0u,
 };
 
 inline constexpr uint8_t kIdentity5334AppEntryPoint0[] = {
@@ -307,6 +321,13 @@ inline constexpr LauncherProfile kProfile5334 = {
         0x132ab78u,
         0x132ab80u,
         0u,
+        0u,
+        0u,
+        0u,
+        {},
+        0u,
+        {},
+        0u,
 };
 
 inline constexpr uint8_t kIdentity5402AppEntryPoint0[] = {
@@ -388,6 +409,13 @@ inline constexpr LauncherProfile kProfile5402 = {
         0x12b8450u,
         0x132fa00u,
         0x132fa08u,
+        0u,
+        0u,
+        0u,
+        0u,
+        {},
+        0u,
+        {},
         0u,
 };
 

--- a/miui-home-hyos-native/launcher_profiles.h
+++ b/miui-home-hyos-native/launcher_profiles.h
@@ -87,6 +87,16 @@ struct LauncherProfile {
     uintptr_t runtime_pointer_offset;
     uintptr_t runtime_state_offset;
     uint32_t runtime_ready_value;
+
+    // Dynamically resolved Dart AOT observation sites. These point to exact
+    // four-instruction return epilogues; no Dart function entry is replaced.
+    uintptr_t dart_drawer_transition_epilogue_offset;
+    uintptr_t dart_overview_enter_epilogue_offset;
+    uintptr_t dart_overview_exit_epilogue_offset;
+    uintptr_t dart_editing_true_epilogue_offsets[4];
+    size_t dart_editing_true_epilogue_count;
+    uintptr_t dart_editing_false_epilogue_offsets[4];
+    size_t dart_editing_false_epilogue_count;
 };
 
 }  // namespace miui_home_profiles

--- a/miui-home-hyos-native/miui_home_native_hook.cpp
+++ b/miui-home-hyos-native/miui_home_native_hook.cpp
@@ -145,6 +145,12 @@ constexpr uint32_t kDartDrawerRemapped = uint32_t{1} << 0u;
 constexpr uint32_t kDartOverviewEnterRemapped = uint32_t{1} << 1u;
 constexpr uint32_t kDartOverviewExitRemapped = uint32_t{1} << 2u;
 constexpr uint32_t kDartEditingRemapped = uint32_t{1} << 3u;
+constexpr uint32_t kDartDrawerPending = uint32_t{1} << 0u;
+constexpr uint32_t kDartOverviewPending = uint32_t{1} << 1u;
+constexpr uint32_t kDartEditingPending = uint32_t{1} << 2u;
+constexpr uint32_t kDartOwnerPending = uint32_t{1} << 3u;
+constexpr uint32_t kDartAllStatePending = kDartDrawerPending |
+        kDartOverviewPending | kDartEditingPending | kDartOwnerPending;
 
 constexpr char kLogTag[] = "MiuiHomeHyosLsp";
 // The first 4371 private-broadcast hook confused its 16-byte Rust x8 result
@@ -554,7 +560,7 @@ void ResetDartStateOwnerForProcess(int32_t process_pid) {
                      __ATOMIC_RELEASE);
     __atomic_store_n(&g_editing_state_observation, uint64_t{0},
                      __ATOMIC_RELEASE);
-    __atomic_store_n(&g_dart_state_publish_pending, uint32_t{1} << 3u,
+    __atomic_store_n(&g_dart_state_publish_pending, kDartOwnerPending,
                      __ATOMIC_RELEASE);
     __atomic_store_n(&g_dart_drawer_active_count, uint32_t{0},
                      __ATOMIC_RELEASE);
@@ -1365,16 +1371,14 @@ void HookBroadcastReceiverOnReceive(void* receiver, void* context, void* intent)
         }
         __atomic_fetch_add(&g_arbiter_state_passthrough_count, uint32_t{1},
                            __ATOMIC_RELAXED);
+        // Make the dispatcher the sole pending-state consumer. Queue every
+        // generation-bound value so a transient send failure remains owned by
+        // its retry loop instead of depending on another receiver callback.
+        __atomic_fetch_or(&g_dart_state_publish_pending,
+                          kDartAllStatePending,
+                          __ATOMIC_RELEASE);
         EnsureDartStatePublisherThread();
-        PublishDrawerStateForCurrentGeneration();
-        PublishOverviewStateForCurrentGeneration();
-        PublishEditingStateForCurrentGeneration();
         PublishXiaoAiStateForCurrentGeneration();
-        // A MotionEvent getter can still run below Flutter/Rust on 1.ui, so it
-        // is not a safe publication boundary.  Drain Dart's atomic-only
-        // observations only after Xiaomi's authenticated receiver has
-        // returned; this callback is the proven non-Dart reentry boundary.
-        PublishPendingDartStates(AtomicLoad(&g_dart_state_owner_epoch));
         // A status query deliberately rides this authenticated action. Reply
         // after the original receiver and publisher setup so readiness covers
         // the actual safe drain boundary.
@@ -1927,10 +1931,6 @@ bool PublishDartStateOwnerForCurrentGeneration(uint64_t owner_epoch) {
 }
 
 void PublishPendingDartStates(uint64_t owner_epoch) {
-    constexpr uint32_t kDrawerPending = uint32_t{1} << 0u;
-    constexpr uint32_t kOverviewPending = uint32_t{1} << 1u;
-    constexpr uint32_t kEditingPending = uint32_t{1} << 2u;
-    constexpr uint32_t kOwnerPending = uint32_t{1} << 3u;
     if (owner_epoch == 0u ||
             AtomicLoad(&g_dart_state_owner_epoch) != owner_epoch) {
         return;
@@ -1939,16 +1939,16 @@ void PublishPendingDartStates(uint64_t owner_epoch) {
             &g_dart_state_publish_pending, uint32_t{0}, __ATOMIC_ACQ_REL);
     if (pending == 0u) return;
 
-    if ((pending & kOwnerPending) != 0u) {
+    if ((pending & kDartOwnerPending) != 0u) {
         PublishDartStateOwnerForCurrentGeneration(owner_epoch);
     }
-    if ((pending & kDrawerPending) != 0u) {
+    if ((pending & kDartDrawerPending) != 0u) {
         PublishDrawerStateForCurrentGeneration();
     }
-    if ((pending & kOverviewPending) != 0u) {
+    if ((pending & kDartOverviewPending) != 0u) {
         PublishOverviewStateForCurrentGeneration();
     }
-    if ((pending & kEditingPending) != 0u) {
+    if ((pending & kDartEditingPending) != 0u) {
         PublishEditingStateForCurrentGeneration();
     }
 
@@ -1959,38 +1959,38 @@ void PublishPendingDartStates(uint64_t owner_epoch) {
     if (AtomicLoad(&g_dart_state_owner_epoch) != owner_epoch) return;
     const int64_t generation = AtomicLoad(&g_systemui_arbiter_generation);
     uint32_t retry = 0u;
-    if ((pending & kOwnerPending) != 0u &&
+    if ((pending & kDartOwnerPending) != 0u &&
             (AtomicLoad(&g_dart_state_owner_published_epoch) != owner_epoch ||
              AtomicLoad(&g_dart_state_owner_published_generation) !=
                      generation)) {
-        retry |= kOwnerPending;
+        retry |= kDartOwnerPending;
     }
     const uint64_t drawer = AtomicLoad(&g_drawer_state_observation);
-    if ((pending & kDrawerPending) != 0u &&
+    if ((pending & kDartDrawerPending) != 0u &&
             DartStateObservationEpoch(drawer) == owner_epoch &&
             (DartStateObservationValue(drawer) !=
                      AtomicLoad(&g_drawer_published_state) ||
              AtomicLoad(&g_drawer_published_generation) != generation ||
              AtomicLoad(&g_drawer_published_owner_epoch) != owner_epoch)) {
-        retry |= kDrawerPending;
+        retry |= kDartDrawerPending;
     }
     const uint64_t overview = AtomicLoad(&g_overview_state_observation);
-    if ((pending & kOverviewPending) != 0u &&
+    if ((pending & kDartOverviewPending) != 0u &&
             DartStateObservationEpoch(overview) == owner_epoch &&
             (DartStateObservationValue(overview) !=
                      AtomicLoad(&g_overview_published_state) ||
              AtomicLoad(&g_overview_published_generation) != generation ||
              AtomicLoad(&g_overview_published_owner_epoch) != owner_epoch)) {
-        retry |= kOverviewPending;
+        retry |= kDartOverviewPending;
     }
     const uint64_t editing = AtomicLoad(&g_editing_state_observation);
-    if ((pending & kEditingPending) != 0u &&
+    if ((pending & kDartEditingPending) != 0u &&
             DartStateObservationEpoch(editing) == owner_epoch &&
             (DartStateObservationValue(editing) !=
                      AtomicLoad(&g_editing_published_state) ||
              AtomicLoad(&g_editing_published_generation) != generation ||
              AtomicLoad(&g_editing_published_owner_epoch) != owner_epoch)) {
-        retry |= kEditingPending;
+        retry |= kDartEditingPending;
     }
     if (retry != 0u) {
         __atomic_fetch_or(&g_dart_state_publish_pending, retry,
@@ -2043,21 +2043,47 @@ void* DartStatePublisherThreadMain(void* data) {
         while (read(fd, &wake_count, sizeof(wake_count)) ==
                 static_cast<ssize_t>(sizeof(wake_count))) {
         }
-        const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
-        PublishPendingDartStates(owner_epoch);
-        if (AtomicLoad(&g_dart_state_publish_pending) != 0u) {
-            timespec retry_delay{0, 16 * 1000 * 1000};
+        uint32_t retry_delay_ms = 16u;
+        for (;;) {
+            const uint64_t owner_epoch =
+                    AtomicLoad(&g_dart_state_owner_epoch);
+            // Mark this publication cycle unresolved before exchanging the
+            // pending mask. Readiness must not observe a transient zero while
+            // a broadcast attempt owns those bits locally.
+            __atomic_store_n(&g_dart_state_publish_failure_epoch,
+                             owner_epoch, __ATOMIC_RELEASE);
+            PublishPendingDartStates(owner_epoch);
+            if (AtomicLoad(&g_dart_state_owner_epoch) == owner_epoch &&
+                    AtomicLoad(&g_dart_state_publish_pending) == 0u) {
+                __atomic_store_n(&g_dart_state_publish_callback_epoch,
+                                 owner_epoch, __ATOMIC_RELEASE);
+                uint64_t failed_epoch = owner_epoch;
+                __atomic_compare_exchange_n(
+                        &g_dart_state_publish_failure_epoch, &failed_epoch,
+                        uint64_t{0}, false, __ATOMIC_RELEASE,
+                        __ATOMIC_RELAXED);
+                // A new Dart observation racing the success publication owns
+                // a raw eventfd wake. Do not suppress that next cycle.
+                if (AtomicLoad(&g_dart_state_publish_pending) == 0u) break;
+            }
+
+            // A re-armed bit is self-sustaining work. Drain any coalesced
+            // eventfd writes and retry with bounded backoff instead of
+            // returning to an indefinite poll or spinning on a broken
+            // broadcast runtime.
+            while (read(fd, &wake_count, sizeof(wake_count)) ==
+                    static_cast<ssize_t>(sizeof(wake_count))) {
+            }
+            timespec retry_delay{
+                    static_cast<time_t>(retry_delay_ms / 1000u),
+                    static_cast<long>((retry_delay_ms % 1000u) *
+                                      1000u * 1000u)};
             while (nanosleep(&retry_delay, &retry_delay) != 0 &&
                     errno == EINTR) {
             }
-            PublishPendingDartStates(owner_epoch);
+            retry_delay_ms = retry_delay_ms < 128u
+                    ? retry_delay_ms * 2u : 250u;
         }
-        __atomic_store_n(&g_dart_state_publish_callback_epoch, owner_epoch,
-                         __ATOMIC_RELEASE);
-        uint64_t failed_epoch = owner_epoch;
-        __atomic_compare_exchange_n(
-                &g_dart_state_publish_failure_epoch, &failed_epoch,
-                uint64_t{0}, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
     }
 }
 
@@ -2084,7 +2110,13 @@ bool WakeDartStatePublisher() {
 
 bool WaitForDartStatePublisherReady(uint64_t owner_epoch) {
     for (uint32_t attempt = 0u; attempt < 50u; ++attempt) {
-        if (AtomicLoad(&g_dart_state_publish_callback_epoch) == owner_epoch) {
+        if (AtomicLoad(&g_dart_state_owner_epoch) != owner_epoch) {
+            return false;
+        }
+        if (AtomicLoad(&g_dart_state_publish_callback_epoch) == owner_epoch &&
+                AtomicLoad(&g_dart_state_publish_pending) == 0u &&
+                AtomicLoad(&g_dart_state_publish_failure_epoch) !=
+                        owner_epoch) {
             return true;
         }
         if (AtomicLoad(&g_dart_state_publish_dispatcher_state) !=
@@ -2104,8 +2136,11 @@ bool EnsureDartStatePublisherThread() {
     const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
     if (AtomicLoad(&g_dart_state_publish_dispatcher_state) == uint32_t{3} &&
             AtomicLoad(&g_dart_state_publish_event_fd) >= 0) {
-        return AtomicLoad(&g_dart_state_publish_callback_epoch) ==
-                        owner_epoch ||
+        return (AtomicLoad(&g_dart_state_publish_callback_epoch) ==
+                        owner_epoch &&
+                AtomicLoad(&g_dart_state_publish_pending) == 0u &&
+                AtomicLoad(&g_dart_state_publish_failure_epoch) !=
+                        owner_epoch) ||
                 (WakeDartStatePublisher() &&
                  WaitForDartStatePublisherReady(owner_epoch));
     }
@@ -2319,6 +2354,7 @@ bool HandleRuntimeStatusQuery(void* intent) {
     const bool dart_scheduler_ready = !dart_scheduler_required ||
             (AtomicLoad(&g_dart_state_atfork_state) == uint32_t{3} &&
              dart_repair_ready &&
+             AtomicLoad(&g_dart_state_publish_pending) == 0u &&
              AtomicLoad(&g_dart_state_publish_dispatcher_state) ==
                      uint32_t{3} &&
              AtomicLoad(&g_dart_state_publish_event_fd) >= 0 &&
@@ -4047,7 +4083,7 @@ void InvalidateDartStateOwnerForRemap() {
     ClearRetiredDartObservation(&g_drawer_state_observation, owner_epoch);
     ClearRetiredDartObservation(&g_overview_state_observation, owner_epoch);
     ClearRetiredDartObservation(&g_editing_state_observation, owner_epoch);
-    __atomic_fetch_or(&g_dart_state_publish_pending, uint32_t{1} << 3u,
+    __atomic_fetch_or(&g_dart_state_publish_pending, kDartOwnerPending,
                       __ATOMIC_RELEASE);
     __android_log_print(ANDROID_LOG_INFO, kLogTag,
                         "invalidated retired Dart state owner epoch=%llu",

--- a/miui-home-hyos-native/miui_home_native_hook.cpp
+++ b/miui-home-hyos-native/miui_home_native_hook.cpp
@@ -13,8 +13,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+#include <sched.h>
+#include <pthread.h>
+#include <poll.h>
 #include <link.h>
 #include <sys/mman.h>
+#include <sys/eventfd.h>
 #include <unistd.h>
 
 extern "C" {
@@ -39,40 +44,34 @@ __attribute__((visibility("hidden")))
 void MiuiHomeHyosInputMonitorPilferHook();
 
 __attribute__((visibility("hidden")))
-void MiuiHomeHyosDartDrawerTransitionCompleteHook();
+void MiuiHomeHyosDartDrawerTransitionEpilogueHook();
 
 __attribute__((visibility("hidden")))
-void MiuiHomeHyosDartDrawerStateObserved(uint32_t visible);
+void MiuiHomeHyosDartOverviewEnterEpilogueHook();
 
 __attribute__((visibility("hidden")))
-void MiuiHomeHyosDartOverviewEnterHook();
+void MiuiHomeHyosDartOverviewExitEpilogueHook();
 
 __attribute__((visibility("hidden")))
-void MiuiHomeHyosDartOverviewExitHook();
+void MiuiHomeHyosDartEditingFalseEpilogueHook();
 
 __attribute__((visibility("hidden")))
-void MiuiHomeHyosDartOverviewStateObserved(uint32_t visible);
-
-__attribute__((visibility("hidden")))
-void MiuiHomeHyosDartEditingQueryHook();
-
-__attribute__((visibility("hidden")))
-void MiuiHomeHyosDartEditingStateObserved(uint32_t editing);
+void MiuiHomeHyosDartEditingTrueEpilogueHook();
 
 __attribute__((visibility("hidden")))
 void MiuiHomeHyosInputMonitorPilferImpl(void* monitor, uintptr_t return_pc);
 
 __attribute__((visibility("hidden")))
-void* miui_home_hyos_dart_transition_complete_original = nullptr;
+void* miui_home_hyos_dart_drawer_epilogue_original = nullptr;
 
 __attribute__((visibility("hidden")))
-void* miui_home_hyos_dart_overview_enter_original = nullptr;
+void* miui_home_hyos_dart_overview_enter_epilogue_original = nullptr;
 
 __attribute__((visibility("hidden")))
-void* miui_home_hyos_dart_overview_exit_original = nullptr;
+void* miui_home_hyos_dart_overview_exit_epilogue_original = nullptr;
 
 __attribute__((visibility("hidden")))
-void* miui_home_hyos_dart_editing_query_original = nullptr;
+void* miui_home_hyos_dart_editing_epilogue_original[8] = {};
 
 __attribute__((visibility("hidden")))
 uintptr_t miui_home_hyos_dart_editing_return_a = 0u;
@@ -80,9 +79,72 @@ uintptr_t miui_home_hyos_dart_editing_return_a = 0u;
 __attribute__((visibility("hidden")))
 uintptr_t miui_home_hyos_dart_editing_return_b = 0u;
 
+// Dart AOT hooks update these cells directly in assembly.  Keep the symbols
+// hidden so ADRP/ADD can address them without a GOT lookup, while C++ owns all
+// publication and status-query reads after the Dart frame has returned.
+// Dart observations are packed as (owner epoch << 2) | state, where state is
+// 1=false and 2=true.  Publishing value and owner identity in one release
+// store prevents a retired AOT mapping from being mistaken for the current
+// launcher owner.
+__attribute__((used, visibility("hidden")))
+volatile uint64_t g_dart_state_owner_epoch = 1;
+__attribute__((used, visibility("hidden")))
+volatile int32_t g_dart_state_owner_pid = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint64_t g_drawer_state_observation = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint64_t g_overview_state_observation = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_overview_dart_enter_count = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_overview_dart_exit_count = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint64_t g_editing_state_observation = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_editing_dart_observe_count = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_state_publish_pending = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_drawer_active_count = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_overview_enter_active_count = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_overview_exit_active_count = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_editing_active_count = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_drawer_retiring = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_overview_enter_retiring = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_overview_exit_retiring = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_editing_retiring = 0;
+__attribute__((used)) volatile uint32_t g_dart_remap_pending_mask = 0;
+__attribute__((used)) volatile uint32_t g_dart_remap_repair_in_flight = 0;
+__attribute__((used, visibility("hidden")))
+volatile int32_t g_dart_state_publish_event_fd = -1;
+__attribute__((used, visibility("hidden")))
+volatile uint64_t g_dart_state_publish_callback_epoch = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint64_t g_dart_state_publish_failure_epoch = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint64_t g_dart_state_owner_published_epoch = 0;
+__attribute__((used, visibility("hidden")))
+volatile int64_t g_dart_state_owner_published_generation = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_state_atfork_state = 0;
+__attribute__((used, visibility("hidden")))
+volatile uint32_t g_dart_state_publish_dispatcher_state = 0;
+
 }
 
 namespace {
+
+constexpr uint32_t kDartDrawerRemapped = uint32_t{1} << 0u;
+constexpr uint32_t kDartOverviewEnterRemapped = uint32_t{1} << 1u;
+constexpr uint32_t kDartOverviewExitRemapped = uint32_t{1} << 2u;
+constexpr uint32_t kDartEditingRemapped = uint32_t{1} << 3u;
 
 constexpr char kLogTag[] = "MiuiHomeHyosLsp";
 // The first 4371 private-broadcast hook confused its 16-byte Rust x8 result
@@ -326,24 +388,21 @@ __attribute__((used)) volatile uint32_t
         g_contextual_motion_snapshot_current_y_bits = 0;
 // Drawer visibility encoding: 0 unknown, 1 Home/not-all-apps, 2 ALL_APPS.
 __attribute__((used)) volatile uint32_t g_drawer_state_hook_state = 0;
-__attribute__((used)) volatile uint32_t g_drawer_state_observed = 0;
 __attribute__((used)) volatile uint32_t g_drawer_published_state = 0;
 __attribute__((used)) volatile int64_t g_drawer_published_generation = 0;
+__attribute__((used)) volatile uint64_t g_drawer_published_owner_epoch = 0;
 __attribute__((used)) volatile uint32_t g_drawer_state_publish_count = 0;
 __attribute__((used)) volatile uint32_t g_overview_state_hook_state = 0;
-__attribute__((used)) volatile uint32_t g_overview_state_observed = 0;
 __attribute__((used)) volatile uint32_t g_overview_published_state = 0;
 __attribute__((used)) volatile int64_t g_overview_published_generation = 0;
+__attribute__((used)) volatile uint64_t g_overview_published_owner_epoch = 0;
 __attribute__((used)) volatile uint32_t g_overview_state_publish_count = 0;
-__attribute__((used)) volatile uint32_t g_overview_dart_enter_count = 0;
-__attribute__((used)) volatile uint32_t g_overview_dart_exit_count = 0;
 // Editing encoding: 0 unknown, 1 idle, 2 editing (including its BottomSheet).
 __attribute__((used)) volatile uint32_t g_editing_state_hook_state = 0;
-__attribute__((used)) volatile uint32_t g_editing_state_observed = 0;
 __attribute__((used)) volatile uint32_t g_editing_published_state = 0;
 __attribute__((used)) volatile int64_t g_editing_published_generation = 0;
+__attribute__((used)) volatile uint64_t g_editing_published_owner_epoch = 0;
 __attribute__((used)) volatile uint32_t g_editing_state_publish_count = 0;
-__attribute__((used)) volatile uint32_t g_editing_dart_observe_count = 0;
 __attribute__((used)) volatile uint32_t g_editing_dart_repair_attempt_count = 0;
 __attribute__((used)) volatile uint32_t g_editing_dart_repair_success_count = 0;
 __attribute__((used)) volatile uint32_t g_editing_dart_repair_failure_count = 0;
@@ -451,6 +510,7 @@ thread_local PendingDownIdentity g_pending_down{};
 thread_local bool g_systemui_owns_back_stream = false;
 thread_local OwnedBackStreamIdentity g_owned_back_stream{};
 thread_local uintptr_t g_last_motion_event = 0u;
+thread_local uintptr_t g_last_dart_maintenance_down = 0u;
 
 template <typename T>
 T AtomicLoad(const T* value) {
@@ -462,9 +522,103 @@ void AtomicStore(T* target, T value) {
     __atomic_store_n(target, value, __ATOMIC_RELEASE);
 }
 
+template <typename T>
+void AtomicStore(volatile T* target, T value) {
+    __atomic_store_n(target, value, __ATOMIC_RELEASE);
+}
+
 uint64_t NextHyosLifecycleSequence() {
     return __atomic_add_fetch(&g_hyos_lifecycle_sequence, uint64_t{1},
                               __ATOMIC_ACQ_REL);
+}
+
+void ResetDartStateOwnerForProcess(int32_t process_pid) {
+    const int32_t inherited_event_fd =
+            AtomicLoad(&g_dart_state_publish_event_fd);
+    if (inherited_event_fd >= 0) close(inherited_event_fd);
+    timespec now{};
+    const uint64_t inherited_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    uint64_t owner_epoch = inherited_epoch + 1u;
+    if (clock_gettime(CLOCK_BOOTTIME, &now) == 0 && now.tv_sec >= 0 &&
+            now.tv_nsec >= 0) {
+        const uint64_t clock_epoch = static_cast<uint64_t>(now.tv_sec) *
+                uint64_t{1000000000} + static_cast<uint64_t>(now.tv_nsec);
+        if (clock_epoch > owner_epoch) owner_epoch = clock_epoch;
+    }
+    if (owner_epoch == 0u) owner_epoch = 1u;
+    __atomic_store_n(&g_dart_state_owner_epoch, owner_epoch,
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_drawer_state_observation, uint64_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_overview_state_observation, uint64_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_editing_state_observation, uint64_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_state_publish_pending, uint32_t{1} << 3u,
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_drawer_active_count, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_overview_enter_active_count, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_overview_exit_active_count, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_editing_active_count, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_drawer_retiring, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_overview_enter_retiring, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_overview_exit_retiring, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_editing_retiring, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_remap_pending_mask, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_remap_repair_in_flight, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_state_publish_event_fd, int32_t{-1},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_state_publish_callback_epoch, uint64_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_state_publish_failure_epoch, uint64_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_state_owner_published_epoch, uint64_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_state_owner_published_generation, int64_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_state_publish_dispatcher_state, uint32_t{0},
+                     __ATOMIC_RELEASE);
+    __atomic_store_n(&g_dart_state_owner_pid, process_pid, __ATOMIC_RELEASE);
+    g_last_dart_maintenance_down = 0u;
+}
+
+void ResetDartStateOwnerAfterFork() {
+    ResetDartStateOwnerForProcess(static_cast<int32_t>(getpid()));
+}
+
+bool EnsureDartStateOwnerForCurrentProcess() {
+    const int32_t process_pid = static_cast<int32_t>(getpid());
+    if (process_pid <= 0) return false;
+    int32_t owner_pid = AtomicLoad(&g_dart_state_owner_pid);
+    if (owner_pid == process_pid) return true;
+
+    for (;;) {
+        if (owner_pid == process_pid) return true;
+        if (owner_pid == -process_pid) {
+            sched_yield();
+            owner_pid = AtomicLoad(&g_dart_state_owner_pid);
+            continue;
+        }
+        int32_t expected = owner_pid;
+        if (__atomic_compare_exchange_n(
+                    &g_dart_state_owner_pid, &expected, -process_pid, false,
+                    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+            break;
+        }
+        owner_pid = expected;
+    }
+    ResetDartStateOwnerForProcess(process_pid);
+    return true;
 }
 
 void RecordFirstLifecycleSequence(volatile uint64_t* target,
@@ -645,6 +799,8 @@ constexpr char kRuntimeStatusQueryExtra[] = "status_query";
 constexpr char kRuntimeStatusNonceExtra[] = "status_nonce";
 constexpr char kAcceptedStateAction[] =
         "dev.codex.miuibackgesturehook.action.MIUI_OVERVIEW_STATE_CHANGE";
+constexpr char kLauncherStateOwnerEpochExtra[] =
+        "launcher_state_owner_epoch";
 
 bool MatchesCode(const uint8_t* base, uintptr_t offset,
                  const uint8_t* expected, size_t expected_size) {
@@ -936,6 +1092,9 @@ bool HandleRuntimeStatusQuery(void* intent);
 void PublishDrawerStateForCurrentGeneration();
 void PublishOverviewStateForCurrentGeneration();
 void PublishEditingStateForCurrentGeneration();
+void PublishPendingDartStates(uint64_t owner_epoch);
+bool EnsureDartStatePublisherThread();
+bool WakeDartStatePublisher();
 void PublishXiaoAiStateForCurrentGeneration();
 bool TryInstallDartDrawerStateHook(
         void* dart_handle,
@@ -955,11 +1114,19 @@ const miui_home_profiles::LauncherProfile* ResolveDartFeatureProfile(
         void* dart_handle, bool retry_rejected = false);
 void TryResolveAndInstallLoadedDartProfile(bool retry_rejected = false);
 void RepairDartDrawerStateHookIfRemapped(
-        const miui_home_profiles::LauncherProfile* profile);
+        const miui_home_profiles::LauncherProfile* profile,
+        bool remap_detected);
 void RepairDartOverviewStateHookIfRemapped(
-        const miui_home_profiles::LauncherProfile* profile);
+        const miui_home_profiles::LauncherProfile* profile,
+        uint32_t remap_mask);
 void RepairDartEditingStateHookIfRemapped(
+        const miui_home_profiles::LauncherProfile* profile,
+        bool remap_detected);
+uint32_t DetectDartStateHookRemapMask(
         const miui_home_profiles::LauncherProfile* profile);
+bool PrepareDartStateHookRetirement(uint32_t remap_mask);
+void FinishDartStateHookRetirement(uint32_t remap_mask);
+void InvalidateDartStateOwnerForRemap();
 
 bool IsExactCallbackName(const char* value, size_t length,
                          const char* expected) {
@@ -1151,13 +1318,30 @@ bool HasArbiterStateMarker(void* intent) {
             generation > 0;
 }
 
-void HookBroadcastReceiverOnReceive(void* receiver, void* context, void* intent) {
+__attribute__((noinline))
+bool TryCallOriginalBroadcastReceiverOnReceive(void* receiver, void* context,
+                                               void* intent) {
+    // Reload immediately before the indirect branch.  Hot reload can retire
+    // the trampoline between two callbacks; keeping a function pointer live
+    // across the observer/publisher calls would turn that window into a null
+    // branch in the Release build.
     BroadcastReceiverOnReceiveFn original =
             reinterpret_cast<BroadcastReceiverOnReceiveFn>(
                     AtomicLoad(&g_original_broadcast_receiver_on_receive));
-    if (original == nullptr) return;
+    if (original == nullptr) return false;
+    original(receiver, context, intent);
+    return true;
+}
+
+void HookBroadcastReceiverOnReceive(void* receiver, void* context, void* intent) {
+    if (IsLauncherProcess() &&
+            !EnsureDartStateOwnerForCurrentProcess()) {
+        (void)TryCallOriginalBroadcastReceiverOnReceive(
+                receiver, context, intent);
+        return;
+    }
     if (intent == nullptr) {
-        original(receiver, context, intent);
+        (void)TryCallOriginalBroadcastReceiverOnReceive(receiver, context, intent);
         return;
     }
     const bool arbiter_action = IntentActionEquals(intent, kArbiterStateAction) ||
@@ -1165,27 +1349,39 @@ void HookBroadcastReceiverOnReceive(void* receiver, void* context, void* intent)
     if (arbiter_action && HasArbiterStateMarker(intent)) {
         __atomic_fetch_add(&g_arbiter_state_marked_count, uint32_t{1},
                            __ATOMIC_RELAXED);
-        // A status query deliberately rides the already authenticated
-        // SystemUI arbiter-state action so it reaches Xiaomi's existing
-        // native receiver without adding a second launcher receiver.
         ObserveArbiterStateIntent(intent);
-        HandleRuntimeStatusQuery(intent);
         // Android 17 reuses Xiaomi's protected fsgesture receiver as the
         // carrier. Its native callback owns launcher-side FSG-region refresh;
         // consuming the marked broadcast here leaves later app gestures
         // redirected before GesturesBackTouchProcessor. Authentication only
         // observes module state, then the original receiver must see the exact
         // unchanged intent and keep Xiaomi's native state machine intact.
+        if (!TryCallOriginalBroadcastReceiverOnReceive(receiver, context, intent)) {
+            // The trampoline may be retired between callbacks during hot
+            // reload.  Without the Xiaomi receiver having run, none of the
+            // mirrored or pending Dart state is authenticated for this
+            // broadcast, so fail closed and wait for the next one.
+            return;
+        }
         __atomic_fetch_add(&g_arbiter_state_passthrough_count, uint32_t{1},
                            __ATOMIC_RELAXED);
-        original(receiver, context, intent);
+        EnsureDartStatePublisherThread();
         PublishDrawerStateForCurrentGeneration();
         PublishOverviewStateForCurrentGeneration();
         PublishEditingStateForCurrentGeneration();
         PublishXiaoAiStateForCurrentGeneration();
+        // A MotionEvent getter can still run below Flutter/Rust on 1.ui, so it
+        // is not a safe publication boundary.  Drain Dart's atomic-only
+        // observations only after Xiaomi's authenticated receiver has
+        // returned; this callback is the proven non-Dart reentry boundary.
+        PublishPendingDartStates(AtomicLoad(&g_dart_state_owner_epoch));
+        // A status query deliberately rides this authenticated action. Reply
+        // after the original receiver and publisher setup so readiness covers
+        // the actual safe drain boundary.
+        HandleRuntimeStatusQuery(intent);
         return;
     }
-    original(receiver, context, intent);
+    (void)TryCallOriginalBroadcastReceiverOnReceive(receiver, context, intent);
 }
 
 bool AddBundleBool(void* bundle, const char* key, bool value) {
@@ -1512,12 +1708,30 @@ bool SendNativeBroadcast(const char* action, void* extras) {
     return true;
 }
 
+constexpr uint64_t kDartObservationStateMask = uint64_t{3};
+
+uint64_t PackDartStateObservation(uint64_t owner_epoch, uint32_t state) {
+    return (owner_epoch << 2u) | state;
+}
+
+uint32_t DartStateObservationValue(uint64_t observation) {
+    return static_cast<uint32_t>(observation & kDartObservationStateMask);
+}
+
+uint64_t DartStateObservationEpoch(uint64_t observation) {
+    return observation >> 2u;
+}
+
 void PublishDrawerStateForCurrentGeneration() {
-    const uint32_t observed = AtomicLoad(&g_drawer_state_observed);
+    const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    const uint64_t observation = AtomicLoad(&g_drawer_state_observation);
+    const uint32_t observed = DartStateObservationValue(observation);
     const int64_t generation = AtomicLoad(&g_systemui_arbiter_generation);
-    if ((observed != 1u && observed != 2u) || generation <= 0 ||
+    if (DartStateObservationEpoch(observation) != owner_epoch ||
+            (observed != 1u && observed != 2u) || generation <= 0 ||
             (AtomicLoad(&g_drawer_published_state) == observed &&
-             AtomicLoad(&g_drawer_published_generation) == generation)) {
+             AtomicLoad(&g_drawer_published_generation) == generation &&
+             AtomicLoad(&g_drawer_published_owner_epoch) == owner_epoch)) {
         return;
     }
     uint32_t expected = 0u;
@@ -1531,13 +1745,18 @@ void PublishDrawerStateForCurrentGeneration() {
     void* extras = bundle_default == nullptr ? nullptr : bundle_default();
     const bool sent = extras != nullptr &&
             AddBundleBool(extras, "drawer_visible", observed == 2u) &&
+            AddBundleI64(extras, kLauncherStateOwnerEpochExtra,
+                         static_cast<int64_t>(owner_epoch)) &&
             AddBundleI64(extras, "input_arbiter_generation", generation) &&
             SendNativeBroadcast(kAcceptedStateAction, extras);
-    if (sent && AtomicLoad(&g_drawer_state_observed) == observed &&
+    if (sent && AtomicLoad(&g_drawer_state_observation) == observation &&
+            AtomicLoad(&g_dart_state_owner_epoch) == owner_epoch &&
             AtomicLoad(&g_systemui_arbiter_generation) == generation) {
         __atomic_store_n(&g_drawer_published_state, observed,
                          __ATOMIC_RELEASE);
         __atomic_store_n(&g_drawer_published_generation, generation,
+                         __ATOMIC_RELEASE);
+        __atomic_store_n(&g_drawer_published_owner_epoch, owner_epoch,
                          __ATOMIC_RELEASE);
         __atomic_fetch_add(&g_drawer_state_publish_count, uint32_t{1},
                            __ATOMIC_RELAXED);
@@ -1549,12 +1768,6 @@ void PublishDrawerStateForCurrentGeneration() {
         Log(ANDROID_LOG_WARN, "native drawer state broadcast failed");
     }
     AtomicStore(&g_drawer_state_publish_in_flight, uint32_t{0});
-}
-
-void HandleDartDrawerStateObserved(uint32_t visible) {
-    const uint32_t observed = visible != 0u ? uint32_t{2} : uint32_t{1};
-    __atomic_store_n(&g_drawer_state_observed, observed, __ATOMIC_RELEASE);
-    PublishDrawerStateForCurrentGeneration();
 }
 
 void HookDrawerStateHandler(int64_t port, uint8_t* data, uint32_t length,
@@ -1575,16 +1788,24 @@ void HookDrawerStateHandler(int64_t port, uint8_t* data, uint32_t length,
         Log(ANDROID_LOG_WARN, "ignored malformed native drawer-state bridge call");
         return;
     }
-    __atomic_store_n(&g_drawer_state_observed, observed, __ATOMIC_RELEASE);
+    if (!EnsureDartStateOwnerForCurrentProcess()) return;
+    const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    __atomic_store_n(&g_drawer_state_observation,
+                     PackDartStateObservation(owner_epoch, observed),
+                     __ATOMIC_RELEASE);
     PublishDrawerStateForCurrentGeneration();
 }
 
 void PublishOverviewStateForCurrentGeneration() {
-    const uint32_t observed = AtomicLoad(&g_overview_state_observed);
+    const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    const uint64_t observation = AtomicLoad(&g_overview_state_observation);
+    const uint32_t observed = DartStateObservationValue(observation);
     const int64_t generation = AtomicLoad(&g_systemui_arbiter_generation);
-    if ((observed != 1u && observed != 2u) || generation <= 0 ||
+    if (DartStateObservationEpoch(observation) != owner_epoch ||
+            (observed != 1u && observed != 2u) || generation <= 0 ||
             (AtomicLoad(&g_overview_published_state) == observed &&
-             AtomicLoad(&g_overview_published_generation) == generation)) {
+             AtomicLoad(&g_overview_published_generation) == generation &&
+             AtomicLoad(&g_overview_published_owner_epoch) == owner_epoch)) {
         return;
     }
     uint32_t expected = 0u;
@@ -1598,13 +1819,18 @@ void PublishOverviewStateForCurrentGeneration() {
     void* extras = bundle_default == nullptr ? nullptr : bundle_default();
     const bool sent = extras != nullptr &&
             AddBundleBool(extras, "overview_visible", observed == 2u) &&
+            AddBundleI64(extras, kLauncherStateOwnerEpochExtra,
+                         static_cast<int64_t>(owner_epoch)) &&
             AddBundleI64(extras, "input_arbiter_generation", generation) &&
             SendNativeBroadcast(kAcceptedStateAction, extras);
-    if (sent && AtomicLoad(&g_overview_state_observed) == observed &&
+    if (sent && AtomicLoad(&g_overview_state_observation) == observation &&
+            AtomicLoad(&g_dart_state_owner_epoch) == owner_epoch &&
             AtomicLoad(&g_systemui_arbiter_generation) == generation) {
         __atomic_store_n(&g_overview_published_state, observed,
                          __ATOMIC_RELEASE);
         __atomic_store_n(&g_overview_published_generation, generation,
+                         __ATOMIC_RELEASE);
+        __atomic_store_n(&g_overview_published_owner_epoch, owner_epoch,
                          __ATOMIC_RELEASE);
         __atomic_fetch_add(&g_overview_state_publish_count, uint32_t{1},
                            __ATOMIC_RELAXED);
@@ -1618,19 +1844,16 @@ void PublishOverviewStateForCurrentGeneration() {
     AtomicStore(&g_overview_state_publish_in_flight, uint32_t{0});
 }
 
-void HandleOverviewStateObserved(bool visible) {
-    __atomic_store_n(&g_overview_state_observed,
-                     visible ? uint32_t{2} : uint32_t{1},
-                     __ATOMIC_RELEASE);
-    PublishOverviewStateForCurrentGeneration();
-}
-
 void PublishEditingStateForCurrentGeneration() {
-    const uint32_t observed = AtomicLoad(&g_editing_state_observed);
+    const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    const uint64_t observation = AtomicLoad(&g_editing_state_observation);
+    const uint32_t observed = DartStateObservationValue(observation);
     const int64_t generation = AtomicLoad(&g_systemui_arbiter_generation);
-    if ((observed != 1u && observed != 2u) || generation <= 0 ||
+    if (DartStateObservationEpoch(observation) != owner_epoch ||
+            (observed != 1u && observed != 2u) || generation <= 0 ||
             (AtomicLoad(&g_editing_published_state) == observed &&
-             AtomicLoad(&g_editing_published_generation) == generation)) {
+             AtomicLoad(&g_editing_published_generation) == generation &&
+             AtomicLoad(&g_editing_published_owner_epoch) == owner_epoch)) {
         return;
     }
     uint32_t expected = 0u;
@@ -1644,13 +1867,18 @@ void PublishEditingStateForCurrentGeneration() {
     void* extras = bundle_default == nullptr ? nullptr : bundle_default();
     const bool sent = extras != nullptr &&
             AddBundleBool(extras, "launcher_editing", observed == 2u) &&
+            AddBundleI64(extras, kLauncherStateOwnerEpochExtra,
+                         static_cast<int64_t>(owner_epoch)) &&
             AddBundleI64(extras, "input_arbiter_generation", generation) &&
             SendNativeBroadcast(kAcceptedStateAction, extras);
-    if (sent && AtomicLoad(&g_editing_state_observed) == observed &&
+    if (sent && AtomicLoad(&g_editing_state_observation) == observation &&
+            AtomicLoad(&g_dart_state_owner_epoch) == owner_epoch &&
             AtomicLoad(&g_systemui_arbiter_generation) == generation) {
         __atomic_store_n(&g_editing_published_state, observed,
                          __ATOMIC_RELEASE);
         __atomic_store_n(&g_editing_published_generation, generation,
+                         __ATOMIC_RELEASE);
+        __atomic_store_n(&g_editing_published_owner_epoch, owner_epoch,
                          __ATOMIC_RELEASE);
         __atomic_fetch_add(&g_editing_state_publish_count, uint32_t{1},
                            __ATOMIC_RELAXED);
@@ -1664,13 +1892,299 @@ void PublishEditingStateForCurrentGeneration() {
     AtomicStore(&g_editing_state_publish_in_flight, uint32_t{0});
 }
 
-void HandleEditingStateObserved(bool editing) {
-    __atomic_fetch_add(&g_editing_dart_observe_count, uint32_t{1},
-                       __ATOMIC_RELAXED);
-    __atomic_store_n(&g_editing_state_observed,
-                     editing ? uint32_t{2} : uint32_t{1},
+bool PublishDartStateOwnerForCurrentGeneration(uint64_t owner_epoch) {
+    const int64_t generation = AtomicLoad(&g_systemui_arbiter_generation);
+    if (owner_epoch == 0u ||
+            AtomicLoad(&g_dart_state_owner_epoch) != owner_epoch ||
+            generation <= 0) {
+        return false;
+    }
+    if (AtomicLoad(&g_dart_state_owner_published_epoch) == owner_epoch &&
+            AtomicLoad(&g_dart_state_owner_published_generation) ==
+                    generation) {
+        return true;
+    }
+    BundleDefaultFn bundle_default = ResolveLauncherSymbol<BundleDefaultFn>(
+            "Bundle_default");
+    void* extras = bundle_default == nullptr ? nullptr : bundle_default();
+    const bool sent = extras != nullptr &&
+            AddBundleI64(extras, kLauncherStateOwnerEpochExtra,
+                         static_cast<int64_t>(owner_epoch)) &&
+            AddBundleI64(extras, "input_arbiter_generation", generation) &&
+            SendNativeBroadcast(kAcceptedStateAction, extras);
+    if (sent && AtomicLoad(&g_dart_state_owner_epoch) == owner_epoch &&
+            AtomicLoad(&g_systemui_arbiter_generation) == generation) {
+        __atomic_store_n(&g_dart_state_owner_published_epoch, owner_epoch,
+                         __ATOMIC_RELEASE);
+        __atomic_store_n(&g_dart_state_owner_published_generation, generation,
+                         __ATOMIC_RELEASE);
+        return true;
+    }
+    if (!sent) {
+        Log(ANDROID_LOG_WARN, "native Dart owner reset broadcast failed");
+    }
+    return false;
+}
+
+void PublishPendingDartStates(uint64_t owner_epoch) {
+    constexpr uint32_t kDrawerPending = uint32_t{1} << 0u;
+    constexpr uint32_t kOverviewPending = uint32_t{1} << 1u;
+    constexpr uint32_t kEditingPending = uint32_t{1} << 2u;
+    constexpr uint32_t kOwnerPending = uint32_t{1} << 3u;
+    if (owner_epoch == 0u ||
+            AtomicLoad(&g_dart_state_owner_epoch) != owner_epoch) {
+        return;
+    }
+    const uint32_t pending = __atomic_exchange_n(
+            &g_dart_state_publish_pending, uint32_t{0}, __ATOMIC_ACQ_REL);
+    if (pending == 0u) return;
+
+    if ((pending & kOwnerPending) != 0u) {
+        PublishDartStateOwnerForCurrentGeneration(owner_epoch);
+    }
+    if ((pending & kDrawerPending) != 0u) {
+        PublishDrawerStateForCurrentGeneration();
+    }
+    if ((pending & kOverviewPending) != 0u) {
+        PublishOverviewStateForCurrentGeneration();
+    }
+    if ((pending & kEditingPending) != 0u) {
+        PublishEditingStateForCurrentGeneration();
+    }
+
+    // A concurrent Dart transition, an in-flight publisher, or a failed send
+    // must remain eligible for the next authenticated arbiter receive. Re-arm
+    // only the state whose observed value is still not published for the
+    // current generation.
+    if (AtomicLoad(&g_dart_state_owner_epoch) != owner_epoch) return;
+    const int64_t generation = AtomicLoad(&g_systemui_arbiter_generation);
+    uint32_t retry = 0u;
+    if ((pending & kOwnerPending) != 0u &&
+            (AtomicLoad(&g_dart_state_owner_published_epoch) != owner_epoch ||
+             AtomicLoad(&g_dart_state_owner_published_generation) !=
+                     generation)) {
+        retry |= kOwnerPending;
+    }
+    const uint64_t drawer = AtomicLoad(&g_drawer_state_observation);
+    if ((pending & kDrawerPending) != 0u &&
+            DartStateObservationEpoch(drawer) == owner_epoch &&
+            (DartStateObservationValue(drawer) !=
+                     AtomicLoad(&g_drawer_published_state) ||
+             AtomicLoad(&g_drawer_published_generation) != generation ||
+             AtomicLoad(&g_drawer_published_owner_epoch) != owner_epoch)) {
+        retry |= kDrawerPending;
+    }
+    const uint64_t overview = AtomicLoad(&g_overview_state_observation);
+    if ((pending & kOverviewPending) != 0u &&
+            DartStateObservationEpoch(overview) == owner_epoch &&
+            (DartStateObservationValue(overview) !=
+                     AtomicLoad(&g_overview_published_state) ||
+             AtomicLoad(&g_overview_published_generation) != generation ||
+             AtomicLoad(&g_overview_published_owner_epoch) != owner_epoch)) {
+        retry |= kOverviewPending;
+    }
+    const uint64_t editing = AtomicLoad(&g_editing_state_observation);
+    if ((pending & kEditingPending) != 0u &&
+            DartStateObservationEpoch(editing) == owner_epoch &&
+            (DartStateObservationValue(editing) !=
+                     AtomicLoad(&g_editing_published_state) ||
+             AtomicLoad(&g_editing_published_generation) != generation ||
+             AtomicLoad(&g_editing_published_owner_epoch) != owner_epoch)) {
+        retry |= kEditingPending;
+    }
+    if (retry != 0u) {
+        __atomic_fetch_or(&g_dart_state_publish_pending, retry,
+                          __ATOMIC_RELEASE);
+    }
+}
+
+void* DartStatePublisherThreadMain(void* data) {
+    const int fd = static_cast<int>(reinterpret_cast<intptr_t>(data));
+    const uint64_t initial_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    if (fd < 0) {
+        __atomic_store_n(&g_dart_state_publish_dispatcher_state,
+                         uint32_t{6}, __ATOMIC_RELEASE);
+        __atomic_store_n(&g_dart_state_publish_failure_epoch, initial_epoch,
+                         __ATOMIC_RELEASE);
+        return nullptr;
+    }
+    __atomic_store_n(&g_dart_state_publish_dispatcher_state, uint32_t{3},
                      __ATOMIC_RELEASE);
-    PublishEditingStateForCurrentGeneration();
+    __atomic_store_n(&g_dart_state_publish_failure_epoch, uint64_t{0},
+                     __ATOMIC_RELEASE);
+
+    pollfd descriptor{fd, POLLIN, 0};
+    for (;;) {
+        descriptor.revents = 0;
+        const int polled = poll(&descriptor, 1u, -1);
+        if (polled < 0 && errno == EINTR) continue;
+        if (polled <= 0 || (descriptor.revents & POLLIN) == 0) {
+            __atomic_store_n(&g_dart_state_publish_failure_epoch,
+                             AtomicLoad(&g_dart_state_owner_epoch),
+                             __ATOMIC_RELEASE);
+            __atomic_store_n(&g_dart_state_publish_dispatcher_state,
+                             uint32_t{6}, __ATOMIC_RELEASE);
+            // Keep the terminal fd allocated until process exit. A Dart hook
+            // can have loaded it immediately before this failure; closing it
+            // here could redirect that raw write into a reused descriptor.
+            return nullptr;
+        }
+        uint64_t wake_count = 0u;
+        while (read(fd, &wake_count, sizeof(wake_count)) ==
+                static_cast<ssize_t>(sizeof(wake_count))) {
+        }
+
+        // Keep publication outside the triggering Dart frame. State changes
+        // within one display interval coalesce into the latest immutable
+        // observation, while the thread remains fully asleep when idle.
+        timespec delay{0, 16 * 1000 * 1000};
+        while (nanosleep(&delay, &delay) != 0 && errno == EINTR) {
+        }
+        while (read(fd, &wake_count, sizeof(wake_count)) ==
+                static_cast<ssize_t>(sizeof(wake_count))) {
+        }
+        const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+        PublishPendingDartStates(owner_epoch);
+        if (AtomicLoad(&g_dart_state_publish_pending) != 0u) {
+            timespec retry_delay{0, 16 * 1000 * 1000};
+            while (nanosleep(&retry_delay, &retry_delay) != 0 &&
+                    errno == EINTR) {
+            }
+            PublishPendingDartStates(owner_epoch);
+        }
+        __atomic_store_n(&g_dart_state_publish_callback_epoch, owner_epoch,
+                         __ATOMIC_RELEASE);
+        uint64_t failed_epoch = owner_epoch;
+        __atomic_compare_exchange_n(
+                &g_dart_state_publish_failure_epoch, &failed_epoch,
+                uint64_t{0}, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+    }
+}
+
+bool WakeDartStatePublisher() {
+    const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    const int fd = AtomicLoad(&g_dart_state_publish_event_fd);
+    if (fd < 0 ||
+            AtomicLoad(&g_dart_state_publish_dispatcher_state) !=
+                    uint32_t{3}) {
+        __atomic_store_n(&g_dart_state_publish_failure_epoch, owner_epoch,
+                         __ATOMIC_RELEASE);
+        return false;
+    }
+    const uint64_t one = 1u;
+    const ssize_t written = write(fd, &one, sizeof(one));
+    if (written == static_cast<ssize_t>(sizeof(one)) ||
+            (written < 0 && errno == EAGAIN)) {
+        return true;
+    }
+    __atomic_store_n(&g_dart_state_publish_failure_epoch, owner_epoch,
+                     __ATOMIC_RELEASE);
+    return false;
+}
+
+bool WaitForDartStatePublisherReady(uint64_t owner_epoch) {
+    for (uint32_t attempt = 0u; attempt < 50u; ++attempt) {
+        if (AtomicLoad(&g_dart_state_publish_callback_epoch) == owner_epoch) {
+            return true;
+        }
+        if (AtomicLoad(&g_dart_state_publish_dispatcher_state) !=
+                uint32_t{3}) {
+            return false;
+        }
+        timespec delay{0, 1000 * 1000};
+        nanosleep(&delay, nullptr);
+    }
+    __atomic_store_n(&g_dart_state_publish_failure_epoch, owner_epoch,
+                     __ATOMIC_RELEASE);
+    return false;
+}
+
+bool EnsureDartStatePublisherThread() {
+    if (!EnsureDartStateOwnerForCurrentProcess()) return false;
+    const uint64_t owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    if (AtomicLoad(&g_dart_state_publish_dispatcher_state) == uint32_t{3} &&
+            AtomicLoad(&g_dart_state_publish_event_fd) >= 0) {
+        return AtomicLoad(&g_dart_state_publish_callback_epoch) ==
+                        owner_epoch ||
+                (WakeDartStatePublisher() &&
+                 WaitForDartStatePublisherReady(owner_epoch));
+    }
+    uint32_t expected = AtomicLoad(&g_dart_state_publish_dispatcher_state);
+    while (expected != uint32_t{1}) {
+        if (expected == uint32_t{3}) {
+            return AtomicLoad(&g_dart_state_publish_event_fd) >= 0 &&
+                    WakeDartStatePublisher() &&
+                    WaitForDartStatePublisherReady(owner_epoch);
+        }
+        if (expected == uint32_t{6}) return false;
+        if (__atomic_compare_exchange_n(
+                    &g_dart_state_publish_dispatcher_state, &expected,
+                    uint32_t{1}, false, __ATOMIC_ACQ_REL,
+                    __ATOMIC_ACQUIRE)) {
+            break;
+        }
+    }
+    if (expected == uint32_t{1}) {
+        for (uint32_t attempt = 0u; attempt < 50u &&
+                AtomicLoad(&g_dart_state_publish_dispatcher_state) ==
+                        uint32_t{1}; ++attempt) {
+            timespec delay{0, 1000 * 1000};
+            nanosleep(&delay, nullptr);
+        }
+        if (AtomicLoad(&g_dart_state_publish_dispatcher_state) !=
+                    uint32_t{3} ||
+                AtomicLoad(&g_dart_state_publish_event_fd) < 0) {
+            return false;
+        }
+        return WakeDartStatePublisher() &&
+                WaitForDartStatePublisherReady(owner_epoch);
+    }
+
+    const int fd = eventfd(0u, EFD_CLOEXEC | EFD_NONBLOCK);
+    if (fd < 0) {
+        __atomic_store_n(&g_dart_state_publish_dispatcher_state, uint32_t{6},
+                         __ATOMIC_RELEASE);
+        __atomic_store_n(&g_dart_state_publish_failure_epoch,
+                         AtomicLoad(&g_dart_state_owner_epoch),
+                         __ATOMIC_RELEASE);
+        return false;
+    }
+    pthread_attr_t attributes{};
+    pthread_t thread{};
+    const bool attributes_ready = pthread_attr_init(&attributes) == 0;
+    if (attributes_ready) {
+        pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
+    }
+    const int created = attributes_ready
+            ? pthread_create(&thread, &attributes,
+                             DartStatePublisherThreadMain,
+                             reinterpret_cast<void*>(
+                                     static_cast<intptr_t>(fd)))
+            : EINVAL;
+    if (attributes_ready) pthread_attr_destroy(&attributes);
+    if (created != 0) {
+        close(fd);
+        __atomic_store_n(&g_dart_state_publish_dispatcher_state, uint32_t{6},
+                         __ATOMIC_RELEASE);
+        __atomic_store_n(&g_dart_state_publish_failure_epoch,
+                         AtomicLoad(&g_dart_state_owner_epoch),
+                         __ATOMIC_RELEASE);
+        return false;
+    }
+    // Publish only after pthread_create succeeds; a failed setup must never
+    // expose an fd that can be closed and reused under a raw Dart write.
+    __atomic_store_n(&g_dart_state_publish_event_fd, fd, __ATOMIC_RELEASE);
+    for (uint32_t attempt = 0u; attempt < 50u &&
+            AtomicLoad(&g_dart_state_publish_dispatcher_state) ==
+                    uint32_t{1}; ++attempt) {
+        timespec delay{0, 1000 * 1000};
+        nanosleep(&delay, nullptr);
+    }
+    if (AtomicLoad(&g_dart_state_publish_dispatcher_state) != uint32_t{3}) {
+        return false;
+    }
+    return WakeDartStatePublisher() &&
+            WaitForDartStatePublisherReady(owner_epoch);
 }
 
 void PublishXiaoAiStateForCurrentGeneration() {
@@ -1789,16 +2303,44 @@ bool HandleRuntimeStatusQuery(void* intent) {
     const bool editing_required = profile_resolved &&
             (dart_features_required ||
              feature_profile->dart_editing_query_offset != 0u);
+    const bool dart_scheduler_required = profile_resolved &&
+            (dart_features_required ||
+             feature_profile->dart_drawer_transition_complete_offset != 0u ||
+             feature_profile->dart_overview_enter_offset != 0u ||
+             feature_profile->dart_editing_query_offset != 0u);
+    const uint64_t dart_owner_epoch = AtomicLoad(&g_dart_state_owner_epoch);
+    const bool dart_repair_ready =
+            AtomicLoad(&g_dart_remap_pending_mask) == 0u &&
+            AtomicLoad(&g_dart_remap_repair_in_flight) == 0u &&
+            AtomicLoad(&g_dart_drawer_retiring) == 0u &&
+            AtomicLoad(&g_dart_overview_enter_retiring) == 0u &&
+            AtomicLoad(&g_dart_overview_exit_retiring) == 0u &&
+            AtomicLoad(&g_dart_editing_retiring) == 0u;
+    const bool dart_scheduler_ready = !dart_scheduler_required ||
+            (AtomicLoad(&g_dart_state_atfork_state) == uint32_t{3} &&
+             dart_repair_ready &&
+             AtomicLoad(&g_dart_state_publish_dispatcher_state) ==
+                     uint32_t{3} &&
+             AtomicLoad(&g_dart_state_publish_event_fd) >= 0 &&
+             AtomicLoad(&g_dart_state_publish_callback_epoch) ==
+                     dart_owner_epoch &&
+             AtomicLoad(&g_dart_state_publish_failure_epoch) !=
+                     dart_owner_epoch);
     const bool drawer_ready = profile_resolved &&
             (!drawer_required ||
-             AtomicLoad(&g_drawer_state_hook_state) == uint32_t{3});
+             (AtomicLoad(&g_drawer_state_hook_state) == uint32_t{3} &&
+              dart_scheduler_ready));
     const bool overview_ready = profile_resolved &&
             (!overview_required ||
-             AtomicLoad(&g_overview_state_hook_state) == uint32_t{3});
+             (AtomicLoad(&g_overview_state_hook_state) == uint32_t{3} &&
+              dart_scheduler_ready));
     const bool editing_ready = profile_resolved &&
             (!editing_required ||
-             AtomicLoad(&g_editing_state_hook_state) == uint32_t{3});
-    const bool native_ready = profile_resolved && business_state == 3u &&
+             (AtomicLoad(&g_editing_state_hook_state) == uint32_t{3} &&
+              dart_scheduler_ready));
+    const bool native_ready = profile_resolved &&
+            AtomicLoad(&g_dart_state_atfork_state) == uint32_t{3} &&
+            business_state == 3u &&
             bridge_state == 3u && drawer_ready && overview_ready &&
             editing_ready;
     __android_log_print(ANDROID_LOG_INFO, kLogTag,
@@ -2016,6 +2558,7 @@ void TryInstallArbiterBridge() {
 }
 
 bool PublishAcceptedDown(uint32_t edge) {
+    if (!EnsureDartStateOwnerForCurrentProcess()) return false;
     const int64_t generation = AtomicLoad(&g_systemui_arbiter_generation);
     if (!g_pending_down.valid || edge > 1u || generation <= 0 ||
             AtomicLoad(&g_systemui_arbiter_ready) == 0u) {
@@ -2033,6 +2576,9 @@ bool PublishAcceptedDown(uint32_t edge) {
             !AddBundleI32(extras, "input_source", g_pending_down.source) ||
             !AddBundleI32(extras, "input_display_id", 0) ||
             !AddBundleI32(extras, "input_edge", static_cast<int32_t>(edge)) ||
+            !AddBundleI64(extras, kLauncherStateOwnerEpochExtra,
+                          static_cast<int64_t>(AtomicLoad(
+                                  &g_dart_state_owner_epoch))) ||
             !AddBundleI64(extras, "input_arbiter_generation", generation)) {
         return false;
     }
@@ -2717,16 +3263,55 @@ void* HookLauncherDlopen3(const char* filename, int flags) {
     return HookLauncherDlopenForSlot(filename, flags, 3u);
 }
 
+void MaintainLauncherHooksOnActionDown(uint32_t slot_index) {
+    RepairBusinessHooksIfRemapped(slot_index);
+    EnsureDartStatePublisherThread();
+    const auto* profile = CurrentDartFeatureProfile();
+    if (profile == nullptr &&
+            NeedsDartFeatureResolution(CurrentLauncherProfile()) &&
+            AtomicLoad(&g_dart_profile_resolve_state) == uint32_t{0}) {
+        // libflutter may own the AOT load rather than calling through
+        // libapp_launcher's PLT. Acquire only the already-loaded image.
+        TryResolveAndInstallLoadedDartProfile();
+        profile = CurrentDartFeatureProfile();
+    }
+    const uint32_t remap_mask = DetectDartStateHookRemapMask(profile);
+    uint32_t expected = 0u;
+    if (remap_mask != 0u && __atomic_compare_exchange_n(
+                &g_dart_remap_repair_in_flight, &expected, uint32_t{1},
+                false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+        __atomic_fetch_or(&g_dart_remap_pending_mask, remap_mask,
+                          __ATOMIC_ACQ_REL);
+        if (PrepareDartStateHookRetirement(remap_mask)) {
+            InvalidateDartStateOwnerForRemap();
+            RepairDartDrawerStateHookIfRemapped(
+                    profile,
+                    (remap_mask & kDartDrawerRemapped) != 0u);
+            RepairDartOverviewStateHookIfRemapped(profile, remap_mask);
+            RepairDartEditingStateHookIfRemapped(
+                    profile,
+                    (remap_mask & kDartEditingRemapped) != 0u);
+            FinishDartStateHookRetirement(remap_mask);
+            __atomic_store_n(&g_dart_remap_pending_mask,
+                             DetectDartStateHookRemapMask(profile),
+                             __ATOMIC_RELEASE);
+        }
+        __atomic_store_n(&g_dart_remap_repair_in_flight, uint32_t{0},
+                         __ATOMIC_RELEASE);
+    }
+    TryInstallLoadedDartDrawerStateHook(profile);
+}
+
 int32_t HookMotionGetActionForSlot(void* event, uint32_t slot_index,
                                    bool masked) {
     if (slot_index >= kLauncherInputSlotCount) return -1;
+    if (!EnsureDartStateOwnerForCurrentProcess()) return -1;
     // hyos_spawner can resolve app_entry_point before the final Launcher child
     // remaps the APK-backed libapp_launcher text.  The PLT hooks survive that
-    // transition, while an inherited inline-hook state and trampoline can
-    // outlive the actual text patch. Repair only the exact three-prologue loss;
+    // transition, while inherited inline-hook state can outlive the actual
+    // text patch. Repair only the exact return-epilogue loss;
     // the triggering stream remains native because its outer handler may
     // already be on the stack.
-    RepairBusinessHooksIfRemapped(slot_index);
     LauncherInputHookSlot& slot = g_launcher_input_slots[slot_index];
     void* target = masked ? slot.original_action_masked
                           : slot.original_action;
@@ -2734,25 +3319,21 @@ int32_t HookMotionGetActionForSlot(void* event, uint32_t slot_index,
             AtomicLoad(&target));
     if (original == nullptr) return -1;
     const int32_t action = original(event);
-    const auto* profile = CurrentDartFeatureProfile();
-    if (profile == nullptr &&
-            NeedsDartFeatureResolution(CurrentLauncherProfile()) &&
-            AtomicLoad(&g_dart_profile_resolve_state) == uint32_t{0}) {
-        // libflutter may own the actual AOT load rather than calling through
-        // libapp_launcher's PLT. The first ordinary launcher input callback
-        // may therefore acquire the already-loaded image, but never loads it.
-        TryResolveAndInstallLoadedDartProfile();
-        profile = CurrentDartFeatureProfile();
-    }
-    RepairDartDrawerStateHookIfRemapped(profile);
-    RepairDartOverviewStateHookIfRemapped(profile);
-    RepairDartEditingStateHookIfRemapped(profile);
-    TryInstallLoadedDartDrawerStateHook(profile);
     g_last_motion_event = reinterpret_cast<uintptr_t>(event);
     PublishContextualMotionSnapshot(event, action);
     if ((action & 0xff) == 0) {
+        const uintptr_t down_identity = reinterpret_cast<uintptr_t>(event);
+        if (g_last_dart_maintenance_down != down_identity) {
+            g_last_dart_maintenance_down = down_identity;
+            MaintainLauncherHooksOnActionDown(slot_index);
+        }
+        // Dart observers only store epoch-bound atomics and wake the sleeping
+        // dispatcher. Do not publish from a MotionEvent getter: its native
+        // caller can still be an active Flutter/Rust 1.ui frame.
         __atomic_fetch_add(&g_motion_down_capture_count, uint32_t{1},
                            __ATOMIC_RELAXED);
+    } else {
+        g_last_dart_maintenance_down = 0u;
     }
     CaptureMotionAction(event, action);
     return action;
@@ -2991,6 +3572,82 @@ bool InstallContextualSearchLongPressHook(
     return true;
 }
 
+
+constexpr uint32_t kDartReturnX22Epilogue[] = {
+        0xaa1603e0u, 0xaa1d03efu, 0xa8c179fdu, 0xd65f03c0u};
+constexpr uint32_t kDartReturnTrueEpilogue[] = {
+        0x910082c0u, 0xaa1d03efu, 0xa8c179fdu, 0xd65f03c0u};
+constexpr uint32_t kDartReturnFalseEpilogue[] = {
+        0x9100c2c0u, 0xaa1d03efu, 0xa8c179fdu, 0xd65f03c0u};
+
+bool MatchesDartEpilogue(
+        uint8_t* dart_base, uintptr_t offset, const uint32_t* words) {
+    return dart_base != nullptr && offset != 0u && words != nullptr &&
+            DartMappedRangeHasFlags(
+                    dart_base, offset, sizeof(uint32_t) * 4u, PF_R | PF_X) &&
+            MatchesCode(dart_base, offset,
+                        reinterpret_cast<const uint8_t*>(words),
+                        sizeof(uint32_t) * 4u);
+}
+
+bool ResolveDartProfileBase(
+        void* dart_handle,
+        const miui_home_profiles::LauncherProfile* profile,
+        uint8_t** dart_base_out) {
+    if (dart_handle == nullptr || profile == nullptr ||
+            dart_base_out == nullptr) {
+        return false;
+    }
+    void* instructions = dlsym(dart_handle, kDartSnapshotInstructionsSymbol);
+    void* build_id = dlsym(dart_handle, kDartSnapshotBuildIdSymbol);
+    Dl_info info{};
+    auto* dart_base =
+            instructions != nullptr && build_id != nullptr &&
+                    dladdr(instructions, &info) != 0 &&
+                    info.dli_fbase != nullptr && IsDartLibraryPath(info.dli_fname)
+            ? static_cast<uint8_t*>(info.dli_fbase)
+            : nullptr;
+    const bool valid = dart_base != nullptr &&
+            instructions == dart_base +
+                    profile->dart_snapshot_instructions_offset &&
+            build_id == dart_base + profile->dart_snapshot_build_id_offset &&
+            profile->dart_snapshot_build_id != nullptr &&
+            profile->dart_snapshot_build_id_size != 0u &&
+            DartMappedRangeHasFlags(
+                    dart_base, profile->dart_snapshot_instructions_offset,
+                    sizeof(uint32_t), PF_R | PF_X) &&
+            DartMappedRangeHasFlags(
+                    dart_base, profile->dart_snapshot_build_id_offset,
+                    profile->dart_snapshot_build_id_size, PF_R) &&
+            memcmp(build_id, profile->dart_snapshot_build_id,
+                   profile->dart_snapshot_build_id_size) == 0;
+    if (valid) *dart_base_out = dart_base;
+    return valid;
+}
+
+bool InstallDartEpilogue(
+        uint8_t* dart_base, uintptr_t offset, const uint32_t* words,
+        void* replacement, void** original) {
+    if (!MatchesDartEpilogue(dart_base, offset, words) ||
+            replacement == nullptr || original == nullptr) {
+        return false;
+    }
+    *original = nullptr;
+    return InstallInlineHook(dart_base + offset, replacement, original) ==
+                    kHookSuccess &&
+            *original != nullptr;
+}
+
+void RemoveDartEpilogueRange(
+        uint8_t* dart_base, const uintptr_t* offsets, size_t count) {
+    if (dart_base == nullptr || offsets == nullptr) return;
+    for (size_t index = 0u; index < count; ++index) {
+        if (offsets[index] != 0u) {
+            RemoveInlineHook(dart_base + offsets[index]);
+        }
+    }
+}
+
 bool TryInstallDartDrawerStateHook(
         void* dart_handle,
         const miui_home_profiles::LauncherProfile* profile) {
@@ -3007,49 +3664,20 @@ bool TryInstallDartDrawerStateHook(
                 false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
         return AtomicLoad(&g_drawer_state_hook_state) == uint32_t{3};
     }
-    __atomic_store_n(&g_drawer_state_hook_state, uint32_t{1},
-                     __ATOMIC_RELEASE);
+    AtomicStore(&g_drawer_state_hook_state, uint32_t{1});
 
-    void* instructions = dlsym(dart_handle,
-                               kDartSnapshotInstructionsSymbol);
-    void* build_id = dlsym(dart_handle, kDartSnapshotBuildIdSymbol);
-    Dl_info info{};
-    const bool resolved = instructions != nullptr && build_id != nullptr &&
-            dladdr(instructions, &info) != 0 && info.dli_fbase != nullptr &&
-            IsDartLibraryPath(info.dli_fname);
-    auto* dart_base = resolved
-            ? static_cast<uint8_t*>(info.dli_fbase) : nullptr;
-    const bool valid = resolved &&
-            instructions == dart_base +
-                    profile->dart_snapshot_instructions_offset &&
-            build_id == dart_base + profile->dart_snapshot_build_id_offset &&
-            profile->dart_snapshot_build_id != nullptr &&
-            profile->dart_snapshot_build_id_size != 0u &&
-            memcmp(build_id, profile->dart_snapshot_build_id,
-                   profile->dart_snapshot_build_id_size) == 0 &&
+    uint8_t* dart_base = nullptr;
+    const bool valid = ResolveDartProfileBase(
+                               dart_handle, profile, &dart_base) &&
             profile->dart_drawer_progress_end_offset != 0u &&
             profile->dart_drawer_progress_end_prologue != nullptr &&
             profile->dart_drawer_progress_end_prologue_size != 0u &&
             profile->dart_drawer_transition_complete_offset != 0u &&
             profile->dart_drawer_transition_complete_prologue != nullptr &&
             profile->dart_drawer_transition_complete_prologue_size != 0u &&
+            profile->dart_drawer_transition_epilogue_offset != 0u &&
             profile->dart_all_apps_state_slot_offset != 0u &&
             profile->dart_home_state_slot_offset != 0u &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_snapshot_instructions_offset,
-                    sizeof(uint32_t), PF_R | PF_X) &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_snapshot_build_id_offset,
-                    profile->dart_snapshot_build_id_size, PF_R) &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_drawer_progress_end_offset,
-                    profile->dart_drawer_progress_end_prologue_size,
-                    PF_R | PF_X) &&
-            DartMappedRangeHasFlags(
-                    dart_base,
-                    profile->dart_drawer_transition_complete_offset,
-                    profile->dart_drawer_transition_complete_prologue_size,
-                    PF_R | PF_X) &&
             MatchesCode(dart_base,
                         profile->dart_drawer_progress_end_offset,
                         profile->dart_drawer_progress_end_prologue,
@@ -3058,40 +3686,41 @@ bool TryInstallDartDrawerStateHook(
                     dart_base,
                     profile->dart_drawer_transition_complete_offset,
                     profile->dart_drawer_transition_complete_prologue,
-                    profile->dart_drawer_transition_complete_prologue_size);
+                    profile->dart_drawer_transition_complete_prologue_size) &&
+            MatchesDartEpilogue(
+                    dart_base,
+                    profile->dart_drawer_transition_epilogue_offset,
+                    kDartReturnX22Epilogue);
     if (!valid) {
-        __atomic_store_n(&g_drawer_state_hook_state, uint32_t{5},
-                         __ATOMIC_RELEASE);
+        AtomicStore(&g_drawer_state_hook_state, uint32_t{5});
         AtomicStore(&g_dart_drawer_install_in_flight, uint32_t{0});
         Log(ANDROID_LOG_ERROR,
-            "Dart ALL_APPS route rejected snapshot identity or fingerprint");
+            "Dart ALL_APPS route rejected snapshot graph or return epilogue");
         return false;
     }
 
-    if (InstallInlineHook(
-                dart_base + profile->dart_drawer_transition_complete_offset,
+    AtomicStore(&g_dart_drawer_retiring, uint32_t{1});
+    if (!InstallDartEpilogue(
+                dart_base,
+                profile->dart_drawer_transition_epilogue_offset,
+                kDartReturnX22Epilogue,
                 reinterpret_cast<void*>(
-                        MiuiHomeHyosDartDrawerTransitionCompleteHook),
-                &miui_home_hyos_dart_transition_complete_original) !=
-                    kHookSuccess ||
-            AtomicLoad(&miui_home_hyos_dart_transition_complete_original) ==
-                    nullptr) {
-        AtomicStore(&miui_home_hyos_dart_transition_complete_original,
+                        MiuiHomeHyosDartDrawerTransitionEpilogueHook),
+                &miui_home_hyos_dart_drawer_epilogue_original)) {
+        AtomicStore(&miui_home_hyos_dart_drawer_epilogue_original,
                     static_cast<void*>(nullptr));
-        __atomic_store_n(&g_drawer_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
+        AtomicStore(&g_drawer_state_hook_state, uint32_t{6});
         AtomicStore(&g_dart_drawer_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR,
-            "Dart ALL_APPS visibility-callback hook failed");
+        Log(ANDROID_LOG_ERROR, "Dart ALL_APPS return-epilogue hook failed");
         return false;
     }
     AtomicStore(&g_dart_app_handle, dart_handle);
     AtomicStore(&g_dart_app_base, dart_base);
-    __atomic_store_n(&g_drawer_state_hook_state, uint32_t{3},
-                     __ATOMIC_RELEASE);
+    AtomicStore(&g_drawer_state_hook_state, uint32_t{3});
+    AtomicStore(&g_dart_drawer_retiring, uint32_t{0});
     AtomicStore(&g_dart_drawer_install_in_flight, uint32_t{0});
     Log(ANDROID_LOG_INFO,
-        "installed exact Dart ALL_APPS visibility-callback state bridge");
+        "installed post-publication Dart ALL_APPS state bridge");
     if (AtomicLoad(&g_overview_state_hook_state) == uint32_t{1}) {
         TryInstallDartOverviewStateHook(dart_handle, profile);
     }
@@ -3109,95 +3738,77 @@ bool TryInstallDartOverviewStateHook(
                 false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
         return AtomicLoad(&g_overview_state_hook_state) == uint32_t{3};
     }
-    __atomic_store_n(&g_overview_state_hook_state, uint32_t{1},
-                     __ATOMIC_RELEASE);
+    AtomicStore(&g_overview_state_hook_state, uint32_t{1});
 
-    void* instructions = dlsym(dart_handle, kDartSnapshotInstructionsSymbol);
-    void* build_id = dlsym(dart_handle, kDartSnapshotBuildIdSymbol);
-    Dl_info info{};
-    const bool resolved = instructions != nullptr && build_id != nullptr &&
-            dladdr(instructions, &info) != 0 && info.dli_fbase != nullptr &&
-            IsDartLibraryPath(info.dli_fname);
-    auto* dart_base = resolved
-            ? static_cast<uint8_t*>(info.dli_fbase) : nullptr;
-    const bool valid = resolved &&
-            instructions == dart_base +
-                    profile->dart_snapshot_instructions_offset &&
-            build_id == dart_base + profile->dart_snapshot_build_id_offset &&
-            profile->dart_snapshot_build_id != nullptr &&
-            profile->dart_snapshot_build_id_size != 0u &&
-            memcmp(build_id, profile->dart_snapshot_build_id,
-                   profile->dart_snapshot_build_id_size) == 0 &&
+    uint8_t* dart_base = nullptr;
+    const bool valid = ResolveDartProfileBase(
+                               dart_handle, profile, &dart_base) &&
             profile->dart_overview_enter_offset != 0u &&
             profile->dart_overview_enter_prologue != nullptr &&
             profile->dart_overview_enter_prologue_size != 0u &&
             profile->dart_overview_exit_offset != 0u &&
             profile->dart_overview_exit_prologue != nullptr &&
             profile->dart_overview_exit_prologue_size != 0u &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_snapshot_instructions_offset,
-                    sizeof(uint32_t), PF_R | PF_X) &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_snapshot_build_id_offset,
-                    profile->dart_snapshot_build_id_size, PF_R) &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_overview_enter_offset,
-                    profile->dart_overview_enter_prologue_size,
-                    PF_R | PF_X) &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_overview_exit_offset,
-                    profile->dart_overview_exit_prologue_size,
-                    PF_R | PF_X) &&
+            profile->dart_overview_enter_epilogue_offset != 0u &&
+            profile->dart_overview_exit_epilogue_offset != 0u &&
             MatchesCode(dart_base, profile->dart_overview_enter_offset,
                         profile->dart_overview_enter_prologue,
                         profile->dart_overview_enter_prologue_size) &&
             MatchesCode(dart_base, profile->dart_overview_exit_offset,
                         profile->dart_overview_exit_prologue,
-                        profile->dart_overview_exit_prologue_size);
+                        profile->dart_overview_exit_prologue_size) &&
+            MatchesDartEpilogue(
+                    dart_base, profile->dart_overview_enter_epilogue_offset,
+                    kDartReturnX22Epilogue) &&
+            MatchesDartEpilogue(
+                    dart_base, profile->dart_overview_exit_epilogue_offset,
+                    kDartReturnX22Epilogue);
     if (!valid) {
-        __atomic_store_n(&g_overview_state_hook_state, uint32_t{5},
-                         __ATOMIC_RELEASE);
+        AtomicStore(&g_overview_state_hook_state, uint32_t{5});
         AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
         Log(ANDROID_LOG_ERROR,
-            "Dart Overview route rejected snapshot identity or fingerprint");
+            "Dart Overview route rejected snapshot graph or return epilogue");
         return false;
     }
-    if (InstallInlineHook(
-                dart_base + profile->dart_overview_enter_offset,
-                reinterpret_cast<void*>(MiuiHomeHyosDartOverviewEnterHook),
-                &miui_home_hyos_dart_overview_enter_original) != kHookSuccess ||
-            AtomicLoad(&miui_home_hyos_dart_overview_enter_original) == nullptr) {
-        AtomicStore(&miui_home_hyos_dart_overview_enter_original,
-                    static_cast<void*>(nullptr));
-        __atomic_store_n(&g_overview_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
+
+    AtomicStore(&g_dart_overview_enter_retiring, uint32_t{1});
+    AtomicStore(&g_dart_overview_exit_retiring, uint32_t{1});
+    if (!InstallDartEpilogue(
+                dart_base, profile->dart_overview_enter_epilogue_offset,
+                kDartReturnX22Epilogue,
+                reinterpret_cast<void*>(
+                        MiuiHomeHyosDartOverviewEnterEpilogueHook),
+                &miui_home_hyos_dart_overview_enter_epilogue_original)) {
+        AtomicStore(&g_overview_state_hook_state, uint32_t{6});
         AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR, "Dart Overview enter hook failed");
+        Log(ANDROID_LOG_ERROR, "Dart Overview enter epilogue hook failed");
         return false;
     }
-    if (InstallInlineHook(
-                dart_base + profile->dart_overview_exit_offset,
-                reinterpret_cast<void*>(MiuiHomeHyosDartOverviewExitHook),
-                &miui_home_hyos_dart_overview_exit_original) != kHookSuccess ||
-            AtomicLoad(&miui_home_hyos_dart_overview_exit_original) == nullptr) {
-        RemoveInlineHook(dart_base + profile->dart_overview_enter_offset);
-        AtomicStore(&miui_home_hyos_dart_overview_enter_original,
+    if (!InstallDartEpilogue(
+                dart_base, profile->dart_overview_exit_epilogue_offset,
+                kDartReturnX22Epilogue,
+                reinterpret_cast<void*>(
+                        MiuiHomeHyosDartOverviewExitEpilogueHook),
+                &miui_home_hyos_dart_overview_exit_epilogue_original)) {
+        RemoveInlineHook(
+                dart_base + profile->dart_overview_enter_epilogue_offset);
+        AtomicStore(&miui_home_hyos_dart_overview_enter_epilogue_original,
                     static_cast<void*>(nullptr));
-        AtomicStore(&miui_home_hyos_dart_overview_exit_original,
+        AtomicStore(&miui_home_hyos_dart_overview_exit_epilogue_original,
                     static_cast<void*>(nullptr));
-        __atomic_store_n(&g_overview_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
+        AtomicStore(&g_overview_state_hook_state, uint32_t{6});
         AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR, "Dart Overview exit hook failed");
+        Log(ANDROID_LOG_ERROR, "Dart Overview exit epilogue hook failed");
         return false;
     }
     AtomicStore(&g_dart_app_handle, dart_handle);
     AtomicStore(&g_dart_app_base, dart_base);
-    __atomic_store_n(&g_overview_state_hook_state, uint32_t{3},
-                     __ATOMIC_RELEASE);
+    AtomicStore(&g_overview_state_hook_state, uint32_t{3});
+    AtomicStore(&g_dart_overview_enter_retiring, uint32_t{0});
+    AtomicStore(&g_dart_overview_exit_retiring, uint32_t{0});
     AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
     Log(ANDROID_LOG_INFO,
-        "installed exact Dart Overview enter/exit state bridge");
+        "installed post-publication Dart Overview state bridge");
     return true;
 }
 
@@ -3212,398 +3823,386 @@ bool TryInstallDartEditingStateHook(
                 false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
         return AtomicLoad(&g_editing_state_hook_state) == uint32_t{3};
     }
-    __atomic_store_n(&g_editing_state_hook_state, uint32_t{1},
-                     __ATOMIC_RELEASE);
+    AtomicStore(&g_editing_state_hook_state, uint32_t{1});
 
-    void* instructions = dlsym(dart_handle, kDartSnapshotInstructionsSymbol);
-    void* build_id = dlsym(dart_handle, kDartSnapshotBuildIdSymbol);
-    Dl_info info{};
-    const bool resolved = instructions != nullptr && build_id != nullptr &&
-            dladdr(instructions, &info) != 0 && info.dli_fbase != nullptr &&
-            IsDartLibraryPath(info.dli_fname);
-    auto* dart_base = resolved
-            ? static_cast<uint8_t*>(info.dli_fbase) : nullptr;
-    const bool valid = resolved &&
-            instructions == dart_base +
-                    profile->dart_snapshot_instructions_offset &&
-            build_id == dart_base + profile->dart_snapshot_build_id_offset &&
-            profile->dart_snapshot_build_id != nullptr &&
-            profile->dart_snapshot_build_id_size != 0u &&
-            memcmp(build_id, profile->dart_snapshot_build_id,
-                   profile->dart_snapshot_build_id_size) == 0 &&
+    uint8_t* dart_base = nullptr;
+    const size_t true_count = profile->dart_editing_true_epilogue_count;
+    const size_t false_count = profile->dart_editing_false_epilogue_count;
+    bool valid = ResolveDartProfileBase(dart_handle, profile, &dart_base) &&
             profile->dart_editing_query_offset != 0u &&
             profile->dart_editing_query_prologue != nullptr &&
             profile->dart_editing_query_prologue_size != 0u &&
             profile->dart_editing_query_return_offset_a >= 4u &&
             profile->dart_editing_query_return_offset_b >= 4u &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_editing_query_offset,
-                    profile->dart_editing_query_prologue_size, PF_R | PF_X) &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_editing_query_return_offset_a - 4u,
-                    sizeof(uint32_t), PF_R | PF_X) &&
-            DartMappedRangeHasFlags(
-                    dart_base, profile->dart_editing_query_return_offset_b - 4u,
-                    sizeof(uint32_t), PF_R | PF_X) &&
+            true_count > 0u && true_count <= 4u &&
+            false_count > 0u && false_count <= 4u &&
+            true_count + false_count <= 8u &&
             MatchesCode(dart_base, profile->dart_editing_query_offset,
                         profile->dart_editing_query_prologue,
                         profile->dart_editing_query_prologue_size) &&
             DartBlTargets(dart_base,
-                          profile->dart_editing_query_return_offset_a - 4u,
-                          profile->dart_editing_query_offset) &&
+                    profile->dart_editing_query_return_offset_a - 4u,
+                    profile->dart_editing_query_offset) &&
             DartBlTargets(dart_base,
-                          profile->dart_editing_query_return_offset_b - 4u,
-                          profile->dart_editing_query_offset);
+                    profile->dart_editing_query_return_offset_b - 4u,
+                    profile->dart_editing_query_offset);
+    for (size_t index = 0u; valid && index < true_count; ++index) {
+        valid = MatchesDartEpilogue(
+                dart_base, profile->dart_editing_true_epilogue_offsets[index],
+                kDartReturnTrueEpilogue);
+    }
+    for (size_t index = 0u; valid && index < false_count; ++index) {
+        valid = MatchesDartEpilogue(
+                dart_base, profile->dart_editing_false_epilogue_offsets[index],
+                kDartReturnFalseEpilogue);
+    }
     if (!valid) {
-        __atomic_store_n(&g_editing_state_hook_state, uint32_t{5},
-                         __ATOMIC_RELEASE);
+        AtomicStore(&g_editing_state_hook_state, uint32_t{5});
         AtomicStore(&g_dart_editing_install_in_flight, uint32_t{0});
         Log(ANDROID_LOG_ERROR,
-            "Dart editing route rejected snapshot graph or fingerprint");
+            "Dart editing route rejected caller graph or return epilogues");
         return false;
     }
+
     AtomicStore(&miui_home_hyos_dart_editing_return_a,
                 reinterpret_cast<uintptr_t>(dart_base) +
                         profile->dart_editing_query_return_offset_a);
     AtomicStore(&miui_home_hyos_dart_editing_return_b,
                 reinterpret_cast<uintptr_t>(dart_base) +
                         profile->dart_editing_query_return_offset_b);
-    if (InstallInlineHook(
-                dart_base + profile->dart_editing_query_offset,
-                reinterpret_cast<void*>(MiuiHomeHyosDartEditingQueryHook),
-                &miui_home_hyos_dart_editing_query_original) != kHookSuccess ||
-            AtomicLoad(&miui_home_hyos_dart_editing_query_original) == nullptr) {
-        AtomicStore(&miui_home_hyos_dart_editing_query_original,
-                    static_cast<void*>(nullptr));
+    AtomicStore(&g_dart_editing_retiring, uint32_t{1});
+    size_t installed = 0u;
+    for (size_t index = 0u; index < true_count; ++index) {
+        if (!InstallDartEpilogue(
+                    dart_base,
+                    profile->dart_editing_true_epilogue_offsets[index],
+                    kDartReturnTrueEpilogue,
+                    reinterpret_cast<void*>(
+                            MiuiHomeHyosDartEditingTrueEpilogueHook),
+                    &miui_home_hyos_dart_editing_epilogue_original[
+                            installed])) {
+            break;
+        }
+        ++installed;
+    }
+    for (size_t index = 0u;
+            installed == true_count && index < false_count; ++index) {
+        if (!InstallDartEpilogue(
+                    dart_base,
+                    profile->dart_editing_false_epilogue_offsets[index],
+                    kDartReturnFalseEpilogue,
+                    reinterpret_cast<void*>(
+                            MiuiHomeHyosDartEditingFalseEpilogueHook),
+                    &miui_home_hyos_dart_editing_epilogue_original[
+                            installed])) {
+            break;
+        }
+        ++installed;
+    }
+    if (installed != true_count + false_count) {
+        RemoveDartEpilogueRange(
+                dart_base, profile->dart_editing_true_epilogue_offsets,
+                true_count);
+        RemoveDartEpilogueRange(
+                dart_base, profile->dart_editing_false_epilogue_offsets,
+                false_count);
+        memset(miui_home_hyos_dart_editing_epilogue_original, 0,
+               sizeof(miui_home_hyos_dart_editing_epilogue_original));
         AtomicStore(&miui_home_hyos_dart_editing_return_a, uintptr_t{0});
         AtomicStore(&miui_home_hyos_dart_editing_return_b, uintptr_t{0});
-        __atomic_store_n(&g_editing_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
+        AtomicStore(&g_editing_state_hook_state, uint32_t{6});
         AtomicStore(&g_dart_editing_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR, "Dart editing-state query hook failed");
+        Log(ANDROID_LOG_ERROR, "Dart editing return-epilogue hook failed");
         return false;
     }
     AtomicStore(&g_dart_app_handle, dart_handle);
     AtomicStore(&g_dart_app_base, dart_base);
-    __atomic_store_n(&g_editing_state_hook_state, uint32_t{3},
-                     __ATOMIC_RELEASE);
+    AtomicStore(&g_editing_state_hook_state, uint32_t{3});
+    AtomicStore(&g_dart_editing_retiring, uint32_t{0});
     AtomicStore(&g_dart_editing_install_in_flight, uint32_t{0});
     Log(ANDROID_LOG_INFO,
-        "installed exact Dart launcher editing-state bridge");
+        "installed caller-filtered Dart editing state bridge");
     return true;
 }
 
-void RepairDartDrawerStateHookIfRemapped(
+uint32_t DetectDartStateHookRemapMask(
         const miui_home_profiles::LauncherProfile* profile) {
-    if (profile == nullptr ||
+    auto* dart_base = static_cast<uint8_t*>(AtomicLoad(&g_dart_app_base));
+    if (profile == nullptr || dart_base == nullptr ||
+            profile != CurrentDartFeatureProfile()) {
+        return 0u;
+    }
+    const bool drawer =
+            AtomicLoad(&g_drawer_state_hook_state) == uint32_t{3} &&
+            MatchesDartEpilogue(
+                    dart_base,
+                    profile->dart_drawer_transition_epilogue_offset,
+                    kDartReturnX22Epilogue);
+    const bool overview_installed =
+            AtomicLoad(&g_overview_state_hook_state) == uint32_t{3};
+    const bool enter_original = overview_installed &&
+            MatchesDartEpilogue(
+                    dart_base, profile->dart_overview_enter_epilogue_offset,
+                    kDartReturnX22Epilogue);
+    const bool exit_original = overview_installed &&
+            MatchesDartEpilogue(
+                    dart_base, profile->dart_overview_exit_epilogue_offset,
+                    kDartReturnX22Epilogue);
+    bool editing = false;
+    if (AtomicLoad(&g_editing_state_hook_state) == uint32_t{3}) {
+        for (size_t index = 0u;
+                index < profile->dart_editing_true_epilogue_count; ++index) {
+            editing = editing || MatchesDartEpilogue(
+                    dart_base,
+                    profile->dart_editing_true_epilogue_offsets[index],
+                    kDartReturnTrueEpilogue);
+        }
+        for (size_t index = 0u;
+                index < profile->dart_editing_false_epilogue_count; ++index) {
+            editing = editing || MatchesDartEpilogue(
+                    dart_base,
+                    profile->dart_editing_false_epilogue_offsets[index],
+                    kDartReturnFalseEpilogue);
+        }
+    }
+    return (drawer ? kDartDrawerRemapped : 0u) |
+            (enter_original ? kDartOverviewEnterRemapped : 0u) |
+            (exit_original ? kDartOverviewExitRemapped : 0u) |
+            (editing ? kDartEditingRemapped : 0u);
+}
+
+bool PrepareDartStateHookRetirement(uint32_t remap_mask) {
+    if ((remap_mask & kDartDrawerRemapped) != 0u) {
+        AtomicStore(&g_dart_drawer_retiring, uint32_t{1});
+    }
+    const bool overview_remapped =
+            (remap_mask & (kDartOverviewEnterRemapped |
+                           kDartOverviewExitRemapped)) != 0u;
+    if (overview_remapped) {
+        AtomicStore(&g_dart_overview_enter_retiring, uint32_t{1});
+        AtomicStore(&g_dart_overview_exit_retiring, uint32_t{1});
+    }
+    if ((remap_mask & kDartEditingRemapped) != 0u) {
+        AtomicStore(&g_dart_editing_retiring, uint32_t{1});
+    }
+    auto is_quiet = [remap_mask, overview_remapped]() {
+        return ((remap_mask & kDartDrawerRemapped) == 0u ||
+                AtomicLoad(&g_dart_drawer_active_count) == 0u) &&
+                (!overview_remapped ||
+                 AtomicLoad(&g_dart_overview_enter_active_count) == 0u) &&
+                (!overview_remapped ||
+                 AtomicLoad(&g_dart_overview_exit_active_count) == 0u) &&
+                ((remap_mask & kDartEditingRemapped) == 0u ||
+                 AtomicLoad(&g_dart_editing_active_count) == 0u);
+    };
+    for (uint32_t attempt = 0u; attempt < 8u; ++attempt) {
+        if (is_quiet()) {
+            timespec stable{0, 1000 * 1000};
+            nanosleep(&stable, nullptr);
+            if (is_quiet()) return true;
+        } else {
+            timespec wait{0, 1000 * 1000};
+            nanosleep(&wait, nullptr);
+        }
+    }
+    Log(ANDROID_LOG_WARN,
+        "deferred Dart epilogue repair while an observer is active");
+    return false;
+}
+
+void FinishDartStateHookRetirement(uint32_t remap_mask) {
+    if ((remap_mask & kDartDrawerRemapped) != 0u &&
+            AtomicLoad(&g_drawer_state_hook_state) == uint32_t{3}) {
+        AtomicStore(&g_dart_drawer_retiring, uint32_t{0});
+    }
+    const bool overview_remapped =
+            (remap_mask & (kDartOverviewEnterRemapped |
+                           kDartOverviewExitRemapped)) != 0u;
+    if (overview_remapped &&
+            AtomicLoad(&g_overview_state_hook_state) == uint32_t{3}) {
+        AtomicStore(&g_dart_overview_enter_retiring, uint32_t{0});
+        AtomicStore(&g_dart_overview_exit_retiring, uint32_t{0});
+    }
+    if ((remap_mask & kDartEditingRemapped) != 0u &&
+            AtomicLoad(&g_editing_state_hook_state) == uint32_t{3}) {
+        AtomicStore(&g_dart_editing_retiring, uint32_t{0});
+    }
+}
+
+void ClearRetiredDartObservation(
+        volatile uint64_t* observation, uint64_t owner_epoch) {
+    uint64_t current = AtomicLoad(observation);
+    while (DartStateObservationEpoch(current) < owner_epoch) {
+        if (__atomic_compare_exchange_n(
+                    observation, &current, uint64_t{0}, false,
+                    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+            return;
+        }
+    }
+}
+
+void InvalidateDartStateOwnerForRemap() {
+    const uint64_t owner_epoch = __atomic_add_fetch(
+            &g_dart_state_owner_epoch, uint64_t{1}, __ATOMIC_ACQ_REL);
+    ClearRetiredDartObservation(&g_drawer_state_observation, owner_epoch);
+    ClearRetiredDartObservation(&g_overview_state_observation, owner_epoch);
+    ClearRetiredDartObservation(&g_editing_state_observation, owner_epoch);
+    __atomic_fetch_or(&g_dart_state_publish_pending, uint32_t{1} << 3u,
+                      __ATOMIC_RELEASE);
+    __android_log_print(ANDROID_LOG_INFO, kLogTag,
+                        "invalidated retired Dart state owner epoch=%llu",
+                        static_cast<unsigned long long>(owner_epoch));
+    WakeDartStatePublisher();
+}
+
+bool RetireDartEpilogue(uint8_t* dart_base, uintptr_t offset) {
+    return dart_base != nullptr && offset != 0u &&
+            RemoveInlineHook(dart_base + offset) == kHookSuccess;
+}
+
+void RepairDartDrawerStateHookIfRemapped(
+        const miui_home_profiles::LauncherProfile* profile,
+        bool remap_detected) {
+    if (!remap_detected || profile == nullptr ||
             AtomicLoad(&g_drawer_state_hook_state) != uint32_t{3}) {
         return;
     }
     auto* dart_base = static_cast<uint8_t*>(AtomicLoad(&g_dart_app_base));
     void* dart_handle = AtomicLoad(&g_dart_app_handle);
-    if (dart_base == nullptr || dart_handle == nullptr ||
-            profile != CurrentDartFeatureProfile()) {
-        return;
-    }
-    const uintptr_t active_offset =
-            profile->dart_drawer_transition_complete_offset;
-    const uint8_t* active_prologue =
-            profile->dart_drawer_transition_complete_prologue;
-    const size_t active_prologue_size =
-            profile->dart_drawer_transition_complete_prologue_size;
-    if (active_offset == 0u ||
-            active_prologue == nullptr || active_prologue_size == 0u ||
-            !MatchesCode(dart_base, active_offset, active_prologue,
-                         active_prologue_size)) {
-        return;
-    }
     __atomic_fetch_add(&g_dart_drawer_repair_attempt_count, uint32_t{1},
                        __ATOMIC_RELAXED);
-    __atomic_store_n(&g_dart_drawer_repair_stage, uint32_t{1},
-                     __ATOMIC_RELEASE);
-    uint32_t install_expected = 0u;
-    if (!__atomic_compare_exchange_n(
-                &g_dart_drawer_install_in_flight, &install_expected,
-                uint32_t{1}, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
-        return;
-    }
+    AtomicStore(&g_dart_drawer_repair_stage, uint32_t{2});
     uint32_t expected = 3u;
-    if (!__atomic_compare_exchange_n(&g_drawer_state_hook_state, &expected,
-                                     uint32_t{1}, false,
-                                     __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
-        AtomicStore(&g_dart_drawer_install_in_flight, uint32_t{0});
-        return;
-    }
-    __atomic_store_n(&g_dart_drawer_repair_stage, uint32_t{2},
-                     __ATOMIC_RELEASE);
-    auto* target = dart_base + profile->dart_drawer_transition_complete_offset;
-    if (RemoveInlineHook(target) != kHookSuccess) {
-        __atomic_store_n(&g_drawer_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_dart_drawer_repair_stage, uint32_t{5},
-                         __ATOMIC_RELEASE);
+    if (dart_base == nullptr || dart_handle == nullptr ||
+            !__atomic_compare_exchange_n(
+                    &g_drawer_state_hook_state, &expected, uint32_t{0},
+                    false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE) ||
+            !RetireDartEpilogue(
+                    dart_base,
+                    profile->dart_drawer_transition_epilogue_offset)) {
+        AtomicStore(&g_drawer_state_hook_state, uint32_t{6});
+        AtomicStore(&g_dart_drawer_repair_stage, uint32_t{5});
         __atomic_fetch_add(&g_dart_drawer_repair_failure_count, uint32_t{1},
                            __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_drawer_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR,
-            "failed to unregister stale Dart ALL_APPS visibility hook");
         return;
     }
-    if (!MatchesCode(
-                dart_base, profile->dart_drawer_transition_complete_offset,
-                profile->dart_drawer_transition_complete_prologue,
-                profile->dart_drawer_transition_complete_prologue_size)) {
-        __atomic_store_n(&g_drawer_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_dart_drawer_repair_stage, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_fetch_add(&g_dart_drawer_repair_failure_count, uint32_t{1},
-                           __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_drawer_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR,
-            "Dart ALL_APPS remap repair failed post-unhook fingerprint");
-        return;
-    }
-    AtomicStore(&miui_home_hyos_dart_transition_complete_original,
+    AtomicStore(&miui_home_hyos_dart_drawer_epilogue_original,
                 static_cast<void*>(nullptr));
-    if (InstallInlineHook(
-                target,
-                reinterpret_cast<void*>(
-                        MiuiHomeHyosDartDrawerTransitionCompleteHook),
-                &miui_home_hyos_dart_transition_complete_original) !=
-                    kHookSuccess ||
-            AtomicLoad(&miui_home_hyos_dart_transition_complete_original) ==
-                    nullptr) {
-        AtomicStore(&miui_home_hyos_dart_transition_complete_original,
-                    static_cast<void*>(nullptr));
-        __atomic_store_n(&g_drawer_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_dart_drawer_repair_stage, uint32_t{7},
-                         __ATOMIC_RELEASE);
-        __atomic_fetch_add(&g_dart_drawer_repair_failure_count, uint32_t{1},
-                           __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_drawer_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR,
-            "failed to repair remapped Dart ALL_APPS visibility hook");
-        return;
-    }
-    __atomic_store_n(&g_dart_drawer_repair_stage, uint32_t{3},
-                     __ATOMIC_RELEASE);
-    __atomic_fetch_add(&g_dart_drawer_repair_success_count, uint32_t{1},
-                       __ATOMIC_RELAXED);
-    __atomic_store_n(&g_drawer_state_hook_state, uint32_t{3},
-                     __ATOMIC_RELEASE);
-    AtomicStore(&g_dart_drawer_install_in_flight, uint32_t{0});
-    Log(ANDROID_LOG_INFO,
-        "repaired remapped Dart ALL_APPS visibility hook");
+    const bool installed =
+            TryInstallDartDrawerStateHook(dart_handle, profile);
+    AtomicStore(&g_dart_drawer_repair_stage,
+                installed ? uint32_t{3} : uint32_t{6});
+    __atomic_fetch_add(
+            installed ? &g_dart_drawer_repair_success_count
+                      : &g_dart_drawer_repair_failure_count,
+            uint32_t{1}, __ATOMIC_RELAXED);
+    Log(installed ? ANDROID_LOG_INFO : ANDROID_LOG_ERROR,
+        installed ? "repaired remapped Dart ALL_APPS epilogue"
+                  : "failed to repair remapped Dart ALL_APPS epilogue");
 }
 
 void RepairDartEditingStateHookIfRemapped(
-        const miui_home_profiles::LauncherProfile* profile) {
-    if (profile == nullptr ||
+        const miui_home_profiles::LauncherProfile* profile,
+        bool remap_detected) {
+    if (!remap_detected || profile == nullptr ||
             AtomicLoad(&g_editing_state_hook_state) != uint32_t{3}) {
         return;
     }
     auto* dart_base = static_cast<uint8_t*>(AtomicLoad(&g_dart_app_base));
-    if (dart_base == nullptr || profile != CurrentDartFeatureProfile() ||
-            profile->dart_editing_query_offset == 0u ||
-            profile->dart_editing_query_prologue == nullptr ||
-            profile->dart_editing_query_prologue_size == 0u ||
-            !MatchesCode(dart_base, profile->dart_editing_query_offset,
-                         profile->dart_editing_query_prologue,
-                         profile->dart_editing_query_prologue_size)) {
-        return;
-    }
+    void* dart_handle = AtomicLoad(&g_dart_app_handle);
     __atomic_fetch_add(&g_editing_dart_repair_attempt_count, uint32_t{1},
                        __ATOMIC_RELAXED);
-    __atomic_store_n(&g_editing_dart_repair_stage, uint32_t{1},
-                     __ATOMIC_RELEASE);
-    uint32_t install_expected = 0u;
-    if (!__atomic_compare_exchange_n(
-                &g_dart_editing_install_in_flight, &install_expected,
-                uint32_t{1}, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
-        return;
-    }
+    AtomicStore(&g_editing_dart_repair_stage, uint32_t{2});
     uint32_t expected = 3u;
-    if (!__atomic_compare_exchange_n(&g_editing_state_hook_state, &expected,
-                                     uint32_t{1}, false,
-                                     __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
-        AtomicStore(&g_dart_editing_install_in_flight, uint32_t{0});
-        return;
+    bool retired = dart_base != nullptr && dart_handle != nullptr &&
+            __atomic_compare_exchange_n(
+                    &g_editing_state_hook_state, &expected, uint32_t{0},
+                    false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    for (size_t index = 0u; retired &&
+            index < profile->dart_editing_true_epilogue_count; ++index) {
+        retired = RetireDartEpilogue(
+                dart_base,
+                profile->dart_editing_true_epilogue_offsets[index]);
     }
-    auto* target = dart_base + profile->dart_editing_query_offset;
-    if (RemoveInlineHook(target) != kHookSuccess ||
-            !MatchesCode(dart_base, profile->dart_editing_query_offset,
-                         profile->dart_editing_query_prologue,
-                         profile->dart_editing_query_prologue_size) ||
-            !DartBlTargets(dart_base,
-                    profile->dart_editing_query_return_offset_a - 4u,
-                    profile->dart_editing_query_offset) ||
-            !DartBlTargets(dart_base,
-                    profile->dart_editing_query_return_offset_b - 4u,
-                    profile->dart_editing_query_offset)) {
-        __atomic_store_n(&g_editing_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_editing_dart_repair_stage, uint32_t{5},
-                         __ATOMIC_RELEASE);
+    for (size_t index = 0u; retired &&
+            index < profile->dart_editing_false_epilogue_count; ++index) {
+        retired = RetireDartEpilogue(
+                dart_base,
+                profile->dart_editing_false_epilogue_offsets[index]);
+    }
+    if (!retired) {
+        AtomicStore(&g_editing_state_hook_state, uint32_t{6});
+        AtomicStore(&g_editing_dart_repair_stage, uint32_t{5});
         __atomic_fetch_add(&g_editing_dart_repair_failure_count, uint32_t{1},
                            __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_editing_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR, "Dart editing remap repair validation failed");
         return;
     }
-    AtomicStore(&miui_home_hyos_dart_editing_query_original,
-                static_cast<void*>(nullptr));
-    AtomicStore(&miui_home_hyos_dart_editing_return_a,
-                reinterpret_cast<uintptr_t>(dart_base) +
-                        profile->dart_editing_query_return_offset_a);
-    AtomicStore(&miui_home_hyos_dart_editing_return_b,
-                reinterpret_cast<uintptr_t>(dart_base) +
-                        profile->dart_editing_query_return_offset_b);
-    if (InstallInlineHook(
-                target,
-                reinterpret_cast<void*>(MiuiHomeHyosDartEditingQueryHook),
-                &miui_home_hyos_dart_editing_query_original) != kHookSuccess ||
-            AtomicLoad(&miui_home_hyos_dart_editing_query_original) == nullptr) {
-        AtomicStore(&miui_home_hyos_dart_editing_return_a, uintptr_t{0});
-        AtomicStore(&miui_home_hyos_dart_editing_return_b, uintptr_t{0});
-        __atomic_store_n(&g_editing_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_editing_dart_repair_stage, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_fetch_add(&g_editing_dart_repair_failure_count, uint32_t{1},
-                           __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_editing_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR, "failed to repair Dart editing-state hook");
-        return;
-    }
-    __atomic_store_n(&g_editing_state_hook_state, uint32_t{3},
-                     __ATOMIC_RELEASE);
-    __atomic_store_n(&g_editing_dart_repair_stage, uint32_t{3},
-                     __ATOMIC_RELEASE);
-    __atomic_fetch_add(&g_editing_dart_repair_success_count, uint32_t{1},
-                       __ATOMIC_RELAXED);
-    AtomicStore(&g_dart_editing_install_in_flight, uint32_t{0});
-    Log(ANDROID_LOG_INFO, "repaired remapped Dart editing-state hook");
+    memset(miui_home_hyos_dart_editing_epilogue_original, 0,
+           sizeof(miui_home_hyos_dart_editing_epilogue_original));
+    AtomicStore(&miui_home_hyos_dart_editing_return_a, uintptr_t{0});
+    AtomicStore(&miui_home_hyos_dart_editing_return_b, uintptr_t{0});
+    const bool installed =
+            TryInstallDartEditingStateHook(dart_handle, profile);
+    AtomicStore(&g_editing_dart_repair_stage,
+                installed ? uint32_t{3} : uint32_t{6});
+    __atomic_fetch_add(
+            installed ? &g_editing_dart_repair_success_count
+                      : &g_editing_dart_repair_failure_count,
+            uint32_t{1}, __ATOMIC_RELAXED);
+    Log(installed ? ANDROID_LOG_INFO : ANDROID_LOG_ERROR,
+        installed ? "repaired remapped Dart editing epilogues"
+                  : "failed to repair remapped Dart editing epilogues");
 }
 
 void RepairDartOverviewStateHookIfRemapped(
-        const miui_home_profiles::LauncherProfile* profile) {
-    if (profile == nullptr ||
-            AtomicLoad(&g_overview_state_hook_state) != uint32_t{3} ||
-            profile->dart_overview_enter_offset == 0u) {
+        const miui_home_profiles::LauncherProfile* profile,
+        uint32_t remap_mask) {
+    const uint32_t overview_mask = remap_mask &
+            (kDartOverviewEnterRemapped | kDartOverviewExitRemapped);
+    if (overview_mask == 0u || profile == nullptr ||
+            AtomicLoad(&g_overview_state_hook_state) != uint32_t{3}) {
         return;
     }
     auto* dart_base = static_cast<uint8_t*>(AtomicLoad(&g_dart_app_base));
-    if (dart_base == nullptr || profile != CurrentDartFeatureProfile()) return;
-    const bool enter_original = MatchesCode(
-            dart_base, profile->dart_overview_enter_offset,
-            profile->dart_overview_enter_prologue,
-            profile->dart_overview_enter_prologue_size);
-    const bool exit_original = MatchesCode(
-            dart_base, profile->dart_overview_exit_offset,
-            profile->dart_overview_exit_prologue,
-            profile->dart_overview_exit_prologue_size);
-    if (!enter_original && !exit_original) return;
+    void* dart_handle = AtomicLoad(&g_dart_app_handle);
     __atomic_fetch_add(&g_overview_dart_repair_attempt_count, uint32_t{1},
                        __ATOMIC_RELAXED);
-    __atomic_store_n(&g_overview_dart_repair_stage, uint32_t{1},
-                     __ATOMIC_RELEASE);
-    uint32_t install_expected = 0u;
-    if (!__atomic_compare_exchange_n(
-                &g_dart_overview_install_in_flight, &install_expected,
-                uint32_t{1}, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
-        return;
-    }
+    AtomicStore(&g_overview_dart_repair_stage, uint32_t{2});
     uint32_t expected = 3u;
-    if (!__atomic_compare_exchange_n(&g_overview_state_hook_state, &expected,
-                                     uint32_t{1}, false,
-                                     __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
-        AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
-        return;
-    }
-    auto* enter_target = dart_base + profile->dart_overview_enter_offset;
-    auto* exit_target = dart_base + profile->dart_overview_exit_offset;
-    const int enter_unhook = RemoveInlineHook(enter_target);
-    const int exit_unhook = RemoveInlineHook(exit_target);
-    if (enter_unhook != kHookSuccess || exit_unhook != kHookSuccess) {
-        __atomic_store_n(&g_overview_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_overview_dart_repair_stage, uint32_t{4},
-                         __ATOMIC_RELEASE);
+    const bool retired = dart_base != nullptr && dart_handle != nullptr &&
+            __atomic_compare_exchange_n(
+                    &g_overview_state_hook_state, &expected, uint32_t{0},
+                    false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE) &&
+            RetireDartEpilogue(
+                    dart_base,
+                    profile->dart_overview_enter_epilogue_offset) &&
+            RetireDartEpilogue(
+                    dart_base,
+                    profile->dart_overview_exit_epilogue_offset);
+    if (!retired) {
+        AtomicStore(&g_overview_state_hook_state, uint32_t{6});
+        AtomicStore(&g_overview_dart_repair_stage, uint32_t{5});
         __atomic_fetch_add(&g_overview_dart_repair_failure_count, uint32_t{1},
                            __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR,
-            "failed to unregister stale Dart Overview hooks");
         return;
     }
-    __atomic_store_n(&g_overview_dart_repair_stage, uint32_t{2},
-                     __ATOMIC_RELEASE);
-    if (!MatchesCode(dart_base, profile->dart_overview_enter_offset,
-                     profile->dart_overview_enter_prologue,
-                     profile->dart_overview_enter_prologue_size) ||
-            !MatchesCode(dart_base, profile->dart_overview_exit_offset,
-                         profile->dart_overview_exit_prologue,
-                         profile->dart_overview_exit_prologue_size)) {
-        __atomic_store_n(&g_overview_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_overview_dart_repair_stage, uint32_t{5},
-                         __ATOMIC_RELEASE);
-        __atomic_fetch_add(&g_overview_dart_repair_failure_count, uint32_t{1},
-                           __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR,
-            "Dart Overview remap repair failed post-unhook fingerprint");
-        return;
-    }
-    AtomicStore(&miui_home_hyos_dart_overview_enter_original,
+    AtomicStore(&miui_home_hyos_dart_overview_enter_epilogue_original,
                 static_cast<void*>(nullptr));
-    AtomicStore(&miui_home_hyos_dart_overview_exit_original,
+    AtomicStore(&miui_home_hyos_dart_overview_exit_epilogue_original,
                 static_cast<void*>(nullptr));
-    if (InstallInlineHook(
-                enter_target,
-                reinterpret_cast<void*>(MiuiHomeHyosDartOverviewEnterHook),
-                &miui_home_hyos_dart_overview_enter_original) != kHookSuccess ||
-            AtomicLoad(&miui_home_hyos_dart_overview_enter_original) == nullptr) {
-        __atomic_store_n(&g_overview_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_overview_dart_repair_stage, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_fetch_add(&g_overview_dart_repair_failure_count, uint32_t{1},
-                           __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR, "failed to repair Dart Overview enter hook");
-        return;
-    }
-    if (InstallInlineHook(
-                exit_target,
-                reinterpret_cast<void*>(MiuiHomeHyosDartOverviewExitHook),
-                &miui_home_hyos_dart_overview_exit_original) != kHookSuccess ||
-            AtomicLoad(&miui_home_hyos_dart_overview_exit_original) == nullptr) {
-        RemoveInlineHook(enter_target);
-        AtomicStore(&miui_home_hyos_dart_overview_enter_original,
-                    static_cast<void*>(nullptr));
-        AtomicStore(&miui_home_hyos_dart_overview_exit_original,
-                    static_cast<void*>(nullptr));
-        __atomic_store_n(&g_overview_state_hook_state, uint32_t{6},
-                         __ATOMIC_RELEASE);
-        __atomic_store_n(&g_overview_dart_repair_stage, uint32_t{7},
-                         __ATOMIC_RELEASE);
-        __atomic_fetch_add(&g_overview_dart_repair_failure_count, uint32_t{1},
-                           __ATOMIC_RELAXED);
-        AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
-        Log(ANDROID_LOG_ERROR, "failed to repair Dart Overview exit hook");
-        return;
-    }
-    __atomic_store_n(&g_overview_state_hook_state, uint32_t{3},
-                     __ATOMIC_RELEASE);
-    __atomic_store_n(&g_overview_dart_repair_stage, uint32_t{3},
-                     __ATOMIC_RELEASE);
-    __atomic_fetch_add(&g_overview_dart_repair_success_count, uint32_t{1},
-                       __ATOMIC_RELAXED);
-    AtomicStore(&g_dart_overview_install_in_flight, uint32_t{0});
-    Log(ANDROID_LOG_INFO, "repaired remapped Dart Overview hooks");
+    const bool installed =
+            TryInstallDartOverviewStateHook(dart_handle, profile);
+    AtomicStore(&g_overview_dart_repair_stage,
+                installed ? uint32_t{3} : uint32_t{6});
+    __atomic_fetch_add(
+            installed ? &g_overview_dart_repair_success_count
+                      : &g_overview_dart_repair_failure_count,
+            uint32_t{1}, __ATOMIC_RELAXED);
+    __android_log_print(installed ? ANDROID_LOG_INFO : ANDROID_LOG_ERROR,
+                        kLogTag, "%s Dart Overview epilogues mask=0x%x",
+                        installed ? "repaired remapped"
+                                  : "failed to repair remapped",
+                        overview_mask);
 }
 
 void TryInstallLoadedDartDrawerStateHook(
@@ -4306,6 +4905,12 @@ void BackfillLoadedLibraries() {
 
 void OnLsposedLibraryLoaded(const char* name, void* handle) {
     if (name == nullptr || handle == nullptr) return;
+    if (IsLauncherProcess() &&
+            !EnsureDartStateOwnerForCurrentProcess()) {
+        Log(ANDROID_LOG_ERROR,
+            "launcher child rejected without a process-local Dart owner");
+        return;
+    }
 
     if (EndsWith(name, kHyperRuntimeName)) {
         EnsureLsposedMadviseGuard(name);
@@ -4344,24 +4949,6 @@ void OnLsposedLibraryLoaded(const char* name, void* handle) {
 }  // namespace
 
 extern "C" __attribute__((visibility("hidden")))
-void MiuiHomeHyosDartDrawerStateObserved(uint32_t visible) {
-    HandleDartDrawerStateObserved(visible);
-}
-
-extern "C" __attribute__((visibility("hidden")))
-void MiuiHomeHyosDartOverviewStateObserved(uint32_t visible) {
-    __atomic_fetch_add(visible != 0u ? &g_overview_dart_enter_count
-                                    : &g_overview_dart_exit_count,
-                       uint32_t{1}, __ATOMIC_RELAXED);
-    HandleOverviewStateObserved(visible != 0u);
-}
-
-extern "C" __attribute__((visibility("hidden")))
-void MiuiHomeHyosDartEditingStateObserved(uint32_t editing) {
-    HandleEditingStateObserved(editing != 0u);
-}
-
-extern "C" __attribute__((visibility("hidden")))
 void MiuiHomeHyosInputMonitorPilferImpl(void* monitor, uintptr_t return_pc) {
     HandleInputMonitorPilfer(monitor, return_pc);
 }
@@ -4387,6 +4974,21 @@ NativeOnModuleLoaded native_init(const NativeAPIEntries* entries) {
         Log(ANDROID_LOG_WARN,
             "LSPosed native entry rejected a non-launcher HYOS process");
         return nullptr;
+    }
+    uint32_t atfork_expected = 0u;
+    if (__atomic_compare_exchange_n(
+                &g_dart_state_atfork_state, &atfork_expected, uint32_t{1},
+                false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+        const int atfork_result = pthread_atfork(
+                nullptr, nullptr, ResetDartStateOwnerAfterFork);
+        __atomic_store_n(&g_dart_state_atfork_state,
+                         atfork_result == 0 ? uint32_t{3} : uint32_t{6},
+                         __ATOMIC_RELEASE);
+        if (atfork_result != 0) {
+            __android_log_print(ANDROID_LOG_WARN, kLogTag,
+                                "Dart owner atfork registration failed: %d",
+                                atfork_result);
+        }
     }
     MarkLsposedLauncherSpecialized();
     Log(ANDROID_LOG_INFO,

--- a/miui-home-hyos-native/verify-launcher-profiles.py
+++ b/miui-home-hyos-native/verify-launcher-profiles.py
@@ -305,6 +305,61 @@ def resolve_dart_runtime_profile(
             f"graph={len(editing)}"
         )
     _editing_refresh, editing_query, editing_return_a, editing_return_b = editing[0]
+
+    return_tail = (0xAA1D03EF, 0xA8C179FD, 0xD65F03C0)
+
+    def return_epilogues(start: int, span: int, first: int) -> list[int]:
+        result = []
+        for rva in range(start, start + span, 4):
+            if words(rva, 4) == [first, *return_tail]:
+                result.append(rva)
+        return result
+
+    drawer_callers = []
+    for start, end in executable_ranges:
+        executable_words = words(start, (end - start) // 4)
+        for index, instruction in enumerate(executable_words):
+            caller = start + index * 4
+            if bl_target(caller, instruction) == transition[0]:
+                drawer_callers.append(caller)
+    drawer_caller_prefix = [
+        0xA9BF79FD, 0xAA0F03FD, 0xF9400FA0,
+        0xB8417001, 0x8B1C8021, 0xB840F020,
+        0x8B1C8000, 0xAA0003E1, 0xF9400BA2,
+    ]
+    drawer_epilogue = (
+        drawer_callers[0] + 4 if len(drawer_callers) == 1 else 0
+    )
+    enter_epilogue = selected_enter[0] + 25 * 4
+    exit_epilogue = selected_exit[0] + 40 * 4
+    editing_false_epilogues = return_epilogues(
+        editing_query, 0x200, 0x9100C2C0
+    )
+    editing_true_epilogues = (
+        return_epilogues(
+            editing_query,
+            editing_false_epilogues[0] - editing_query,
+            0x910082C0,
+        )
+        if len(editing_false_epilogues) == 1
+        else []
+    )
+    if (
+        len(drawer_callers) != 1
+        or words(drawer_callers[0] - len(drawer_caller_prefix) * 4,
+                 len(drawer_caller_prefix)) != drawer_caller_prefix
+        or words(drawer_epilogue, 4) != [0xAA1603E0, *return_tail]
+        or words(enter_epilogue, 4) != [0xAA1603E0, *return_tail]
+        or words(exit_epilogue, 4) != [0xAA1603E0, *return_tail]
+        or not 1 <= len(editing_true_epilogues) <= 4
+        or len(editing_false_epilogues) != 1
+    ):
+        raise ValueError(
+            "Dart resolver return epilogues: "
+            f"drawer_callers={len(drawer_callers)} "
+            f"editing_true={len(editing_true_epilogues)} "
+            f"editing_false={len(editing_false_epilogues)}"
+        )
     return {
         "progress_end_offset": drawer_rva,
         "transition_complete_offset": transition[0],
@@ -315,6 +370,11 @@ def resolve_dart_runtime_profile(
         "editing_query_offset": editing_query,
         "editing_query_return_offset_a": editing_return_a,
         "editing_query_return_offset_b": editing_return_b,
+        "drawer_transition_epilogue_offset": drawer_epilogue,
+        "overview_enter_epilogue_offset": enter_epilogue,
+        "overview_exit_epilogue_offset": exit_epilogue,
+        "editing_true_epilogue_offsets": editing_true_epilogues,
+        "editing_false_epilogue_offsets": editing_false_epilogues,
     }
 
 


### PR DESCRIPTION
## Summary
- move Dart state observation to assembly-only atomic stores and defer publication until the authenticated arbiter receiver returns
- fail closed when a Dart trampoline or broadcast receiver trampoline is temporarily unavailable during launcher remap/hot reload
- preserve Dart register/NZCV state without re-entering the Rust runtime from an active Flutter frame

## Validation
- `./gradlew.bat clean :app:assembleRelease` (Release, version 0.11.7 / 94)
- APK v2 signature and 16-byte zip alignment verified
- deployed with `safe_lsposed_native_deploy.py --action deploy --variant Release --skip-build`
- API-102 hot reload verified; current APK mapping and HYOS parent/Launcher relationship verified
- 20 Recents open/close cycles completed with a stable Launcher PID
- formal side-gesture capture recorded accepted-DOWN matching, SystemUI pilfer, Shell start, and committed release
- no new tombstone after deployment; SystemUI PID remained unchanged

Local `analysis/` evidence, APK outputs, signing keys, and build-only environment settings are intentionally excluded from this PR.