### PR TITLE
fix(os3): preserve RETURN_TO_HOME animation continuity across launcher transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -544,6 +544,11 @@ Return-to-home rules:
 - Once the exact Xiaomi CLOSE starts, retain the Shell runner and remote targets until its
   matching native end or a verified launcher-interruption boundary. Do not restore or
   release the preview Surface over a captured native animation.
+- Resolve `LocalWindowAnimImplementor.animTo$lambda$3(...)` only through either observed exact
+  parameter order: `(RectFParams, LocalWindowAnimImplementor)` or
+  `(LocalWindowAnimImplementor, RectFParams)`. Normalize both to the existing
+  implementor/params finish-epoch contract; any other signature or argument-role mismatch
+  fails closed.
 - For one animation and `animTo` epoch, preserve the first exact pre-clear finish snapshot.
   A duplicate `StateManager` end callback after element/target cleanup must not overwrite
   that terminal identity or keep the Shell runner alive.
@@ -572,6 +577,15 @@ Return-to-home rules:
   exact generation and object ownership. Commit transfers that state to Xiaomi;
   cancellation restores only unchanged module-owned state after the application preview is
   fullscreen. Never overwrite an unrelated or replacement native spring.
+- When an accepted DOWN waits for its exact launcher OPEN to end before Shell handoff, keep the
+  wallpaper in App state so Xiaomi's following CLOSE retains its native App-to-Home spring.
+  Suppress only the matching OPEN-finish Home `SystemWallpaperElement.setTo(...)` later in the
+  same main-Looper call stack, bound to the accepted input, OPEN generation and animation,
+  callback epoch, StateManager, wallpaper element, and Xiaomi-derived Home zoom. Expire an
+  unconsumed marker on the next main-Looper turn and invalidate it on a new OPEN or arbiter
+  generation, detach, and hot reload; do not apply the accepted-DOWN admission timeout to this
+  identity-bound marker. Preserve accepted native OPEN merges, ordinary OPEN cleanup, and
+  Xiaomi's native CLOSE `animTo(Home)`.
 - A prepared cancellation must continue through the launcher runner and Shell's normal
   restore transition. Clear only a proven stale close-request gate while the exact
   prepare-open token remains owned; never directly finish or clear the prepared animation.

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/core/HookRuntimeCore.java
@@ -506,6 +506,8 @@ public abstract class HookRuntimeCore extends XposedModule {
             new AtomicReference<>();
     protected final AtomicReference<MiuiHomeAcceptedInputToken>
             miuiHomeAcceptedInputIdentity = new AtomicReference<>();
+    protected final AtomicReference<EndedLauncherOpenWallpaperReset>
+            endedLauncherOpenWallpaperReset = new AtomicReference<>();
     protected final AtomicReference<SystemUiReturnHomeCommitIdentity>
             systemUiReturnHomeCommitIdentity = new AtomicReference<>();
     protected final AtomicReference<MiuiHomeLocalHandoffToken> miuiHomeLocalHandoffToken =
@@ -1215,10 +1217,20 @@ public abstract class HookRuntimeCore extends XposedModule {
         public final int edge;
         public final long generation;
         public final long receivedUptime;
+        public final long miuiHomeOpenBreakGenerationAtDown;
+        public final Object miuiHomeOpenBreakAnimationAtDown;
 
         public MiuiHomeAcceptedInputToken(int eventId, long downTime, int deviceId,
                                           int source, int displayId, int edge,
                                           long generation) {
+            this(eventId, downTime, deviceId, source, displayId, edge,
+                    generation, 0L, null);
+        }
+
+        public MiuiHomeAcceptedInputToken(int eventId, long downTime, int deviceId,
+                                          int source, int displayId, int edge,
+                                          long generation, long openBreakGeneration,
+                                          Object openBreakAnimation) {
             this.eventId = eventId;
             this.downTime = downTime;
             this.deviceId = deviceId;
@@ -1227,6 +1239,8 @@ public abstract class HookRuntimeCore extends XposedModule {
             this.edge = edge;
             this.generation = generation;
             this.receivedUptime = SystemClock.uptimeMillis();
+            this.miuiHomeOpenBreakGenerationAtDown = openBreakGeneration;
+            this.miuiHomeOpenBreakAnimationAtDown = openBreakAnimation;
         }
 
         public boolean isExpired() {
@@ -1235,6 +1249,33 @@ public abstract class HookRuntimeCore extends XposedModule {
             return now - receivedUptime > INPUT_ACCEPTED_TOKEN_TIMEOUT_MS
                     || streamAge < 0L
                     || streamAge > INPUT_ACCEPTED_TOKEN_TIMEOUT_MS;
+        }
+    }
+
+    public static final class EndedLauncherOpenWallpaperReset {
+        public final MiuiHomeAcceptedInputToken inputIdentity;
+        public final long callbackEpoch;
+        public final Object stateManager;
+        public final Object animationIdentity;
+        public final Object wallpaperElement;
+        public final float homeZoom;
+
+        public EndedLauncherOpenWallpaperReset(
+                MiuiHomeAcceptedInputToken inputIdentity,
+                long callbackEpoch, Object stateManager,
+                Object animationIdentity,
+                Object wallpaperElement, float homeZoom) {
+            this.inputIdentity = inputIdentity;
+            this.callbackEpoch = callbackEpoch;
+            this.stateManager = stateManager;
+            this.animationIdentity = animationIdentity;
+            this.wallpaperElement = wallpaperElement;
+            this.homeZoom = homeZoom;
+        }
+
+        public boolean matchesCommand(Object element, float zoom) {
+            return wallpaperElement == element
+                    && Float.compare(homeZoom, zoom) == 0;
         }
     }
 

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/hotreload/HotReloadHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/hotreload/HotReloadHookRuntime.java
@@ -127,6 +127,7 @@ public abstract class HotReloadHookRuntime extends SystemServerHookRuntime {
         miuiLauncherXiaoAiVisible = false;
         acceptedInputToken.set(null);
         miuiHomeAcceptedInputIdentity.set(null);
+        endedLauncherOpenWallpaperReset.set(null);
         Object[] savedContextualSearchNavigationBars =
                 detachAllContextualSearchInputReceiversForHotReload();
         closeHyperOsBackHapticHelper();

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
@@ -322,9 +322,18 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                     classLoader);
             Class<?> rectFParamsClass = Class.forName(
                     MIUI_HOME_RECTF_PARAMS, false, classLoader);
-            Method config = requireExactDeclaredMethod(
-                    implementorClass, "animTo$lambda$3", "void",
-                    rectFParamsClass.getName(), implementorClass.getName());
+            Method config;
+            try {
+                config = requireExactDeclaredMethod(
+                        implementorClass, "animTo$lambda$3", "void",
+                        rectFParamsClass.getName(),
+                        implementorClass.getName());
+            } catch (NoSuchMethodException oldSignature) {
+                config = requireExactDeclaredMethod(
+                        implementorClass, "animTo$lambda$3", "void",
+                        implementorClass.getName(),
+                        rectFParamsClass.getName());
+            }
             recordHookHandle(hook(config)
                     .setId("miui_home_return_home_anim_to_config")
                     .intercept(this::observeMiuiHomeUnifiedAnimToConfigured));
@@ -905,33 +914,40 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
 
     protected Object observeMiuiHomeUnifiedAnimToConfigured(
             XposedInterface.Chain chain) throws Throwable {
+        Object firstArg = chain.getArg(0);
+        Object secondArg = chain.getArg(1);
+        boolean paramsFirst = MIUI_HOME_RECTF_PARAMS.equals(
+                firstArg.getClass().getName());
+        Object params = paramsFirst ? firstArg : secondArg;
+        Object implementor = paramsFirst ? secondArg : firstArg;
         MiuiHomeReturnHomeController controller =
                 miuiHomeReturnHomeController;
         Object configLock = controller == null ? null
                 : controller.resolveUnifiedAnimToConfigLock(
-                chain.getArg(0));
+                params);
         if (configLock != null) {
             synchronized (configLock) {
                 return observeMiuiHomeUnifiedAnimToConfiguredLocked(
-                        chain, controller);
+                        chain, controller, implementor, params);
             }
         }
         return observeMiuiHomeUnifiedAnimToConfiguredLocked(
-                chain, controller);
+                chain, controller, implementor, params);
     }
 
     protected Object observeMiuiHomeUnifiedAnimToConfiguredLocked(
             XposedInterface.Chain chain,
-            MiuiHomeReturnHomeController controller) throws Throwable {
+            MiuiHomeReturnHomeController controller,
+            Object implementor, Object params) throws Throwable {
         Object ownerToken = controller == null ? null
                 : controller.beginUnifiedNativeAnimToConfigHook(
-                chain.getArg(0));
+                params);
         Throwable hookFailure = null;
         String completionReason = "beforeOriginal";
         try {
             if (controller != null
                     && controller.shouldSkipInterruptedUnifiedAnimToConfig(
-                    chain.getArg(1), chain.getArg(0))) {
+                    implementor, params)) {
                 completionReason = "skippedInterruptedConfig";
                 return null;
             }
@@ -940,7 +956,7 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
             completionReason = "originalReturned";
             if (controller != null) {
                 controller.onUnifiedNativeAnimToConfigured(
-                        chain.getArg(1), chain.getArg(0));
+                        implementor, params);
                 completionReason = "configuredReturned";
             }
             return result;
@@ -952,11 +968,11 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
             if (controller != null) {
                 try {
                     controller.onUnifiedNativeAnimToConfigHookCompleted(
-                            chain.getArg(1), chain.getArg(0),
+                            implementor, params,
                             completionReason, hookFailure);
                 } finally {
                     controller.finishUnifiedNativeAnimToConfigHook(
-                            ownerToken, chain.getArg(0),
+                            ownerToken, params,
                             completionReason, hookFailure);
                 }
             }

--- a/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
+++ b/app/src/main/java/dev/codex/miuibackgesturehook/hooks/miuihome/MiuiHomeHookRuntime.java
@@ -660,6 +660,7 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
         miuiHomeOpenBreakGenerationPrepared = true;
         miuiHomeOpenBreakAnimationActive = false;
         miuiHomeOpenBreakCommandPending = false;
+        endedLauncherOpenWallpaperReset.set(null);
         refreshMiuiHomeOpenBreakAvailability(controller, "enable");
         return result;
     }
@@ -676,6 +677,7 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 animationListener, animationIdentity)) {
             return result;
         }
+        endedLauncherOpenWallpaperReset.set(null);
         invalidateMiuiHomeLauncherOpenSnapshot(null, "animationStart");
         if (!miuiHomeOpenBreakGenerationPrepared
                 || miuiHomeOpenBreakGeneration == 0L) {
@@ -729,6 +731,8 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 chain.getThisObject(), endedAnimationIdentity)) {
             return result;
         }
+        armEndedLauncherOpenWallpaperReset(
+                chain.getThisObject(), endedAnimationIdentity);
         invalidateMiuiHomeLauncherOpenSnapshot(
                 endedAnimationIdentity, "animationEnd");
         long callbackEpoch = miuiHomeOpenBreakCallbackEpoch.get();
@@ -749,6 +753,149 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                     miuiHomeOpenBreakController, "animationEnd");
         });
         return result;
+    }
+
+    protected void armEndedLauncherOpenWallpaperReset(
+            Object animationListener, Object endedAnimationIdentity) {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            return;
+        }
+        try {
+            MiuiHomeAcceptedInputToken inputIdentity =
+                    miuiHomeAcceptedInputIdentity.get();
+            long callbackEpoch =
+                    miuiHomeOpenBreakCallbackEpoch.get();
+            Object stateManager = readField(
+                    animationListener, "this$0");
+            if (inputIdentity == null
+                    || stateManager == null
+                    || stateManager != miuiHomeOpenBreakStateManager
+                    || inputIdentity.miuiHomeOpenBreakGenerationAtDown
+                    != miuiHomeOpenBreakGeneration
+                    || inputIdentity.miuiHomeOpenBreakAnimationAtDown
+                    != endedAnimationIdentity
+                    || miuiHomeOpenBreakAnimationIdentity
+                    != endedAnimationIdentity
+                    || !miuiHomeOpenBreakAnimationActive
+                    || miuiHomeOpenBreakGenerationPrepared
+                    || miuiHomeOpenBreakCommandPending) {
+                return;
+            }
+            Object wallpaperElement = readField(
+                    stateManager, "wallpaperElement");
+            if (wallpaperElement == null
+                    || !MIUI_HOME_SYSTEM_WALLPAPER_ELEMENT.equals(
+                    wallpaperElement.getClass().getName())) {
+                return;
+            }
+            Class<?> wallpaperParamsClass = Class.forName(
+                    MIUI_HOME_WALLPAPER_PARAMS, false,
+                    wallpaperElement.getClass().getClassLoader());
+            Object companion = readStaticField(
+                    wallpaperParamsClass, "Companion");
+            Object homeParams = invokeAnyMethod(
+                    companion, "getHomeStateParams", new Object[0]);
+            Object homeZoomValue = invokeAnyMethod(
+                    homeParams, "getZoomOut", new Object[0]);
+            if (!(homeZoomValue instanceof Number)
+                    || miuiHomeAcceptedInputIdentity.get()
+                    != inputIdentity
+                    || miuiHomeOpenBreakCallbackEpoch.get()
+                    != callbackEpoch
+                    || miuiHomeOpenBreakStateManager
+                    != stateManager
+                    || miuiHomeOpenBreakAnimationIdentity
+                    != endedAnimationIdentity) {
+                return;
+            }
+            // ponytail: accepted DOWN is the only launcher-local pre-Shell evidence;
+            // add an authenticated SystemUI claim only if an unclaimed touch exposes this
+            // otherwise hidden wallpaper state.
+            EndedLauncherOpenWallpaperReset marker =
+                    new EndedLauncherOpenWallpaperReset(
+                            inputIdentity, callbackEpoch,
+                            stateManager, endedAnimationIdentity,
+                            wallpaperElement,
+                            ((Number) homeZoomValue).floatValue());
+            endedLauncherOpenWallpaperReset.set(marker);
+            new Handler(Looper.getMainLooper()).post(() -> {
+                if (endedLauncherOpenWallpaperReset.compareAndSet(
+                        marker, null)) {
+                    moduleLog(Log.WARN, TAG,
+                            "Expired unconsumed launcher OPEN wallpaper reset marker"
+                                    + ", eventId="
+                                    + inputIdentity.eventId
+                                    + ", launcherOpenGeneration="
+                                    + inputIdentity.miuiHomeOpenBreakGenerationAtDown);
+                }
+            });
+            moduleLog(Log.INFO, TAG,
+                    "Armed launcher OPEN wallpaper reset suppression"
+                            + ", eventId=" + inputIdentity.eventId
+                            + ", launcherOpenGeneration="
+                            + inputIdentity.miuiHomeOpenBreakGenerationAtDown
+                            + ", animationIdentity="
+                            + shortObject(endedAnimationIdentity));
+        } catch (Throwable throwable) {
+            endedLauncherOpenWallpaperReset.set(null);
+            moduleLog(Log.WARN, TAG,
+                    "Failed to arm launcher OPEN wallpaper reset suppression; "
+                            + "preserving Xiaomi cleanup",
+                    throwable);
+        }
+    }
+
+    protected boolean consumeEndedLauncherOpenWallpaperReset(
+            Object wallpaperElement, Object params) {
+        EndedLauncherOpenWallpaperReset marker =
+                endedLauncherOpenWallpaperReset.get();
+        if (marker == null || Looper.myLooper()
+                != Looper.getMainLooper()) {
+            return false;
+        }
+        try {
+            MiuiHomeAcceptedInputToken inputIdentity =
+                    marker.inputIdentity;
+            Object zoomValue = invokeAnyMethod(
+                    params, "getZoomOut", new Object[0]);
+            if (!(zoomValue instanceof Number)
+                    || !marker.matchesCommand(
+                    wallpaperElement,
+                    ((Number) zoomValue).floatValue())
+                    || miuiHomeAcceptedInputIdentity.get()
+                    != inputIdentity
+                    || inputIdentity.miuiHomeOpenBreakGenerationAtDown
+                    != miuiHomeOpenBreakGeneration
+                    || marker.callbackEpoch
+                    != miuiHomeOpenBreakCallbackEpoch.get()
+                    || marker.stateManager
+                    != miuiHomeOpenBreakStateManager
+                    || marker.animationIdentity
+                    != miuiHomeOpenBreakAnimationIdentity
+                    || inputIdentity.miuiHomeOpenBreakAnimationAtDown
+                    != marker.animationIdentity
+                    || !miuiHomeOpenBreakAnimationActive
+                    || miuiHomeOpenBreakGenerationPrepared
+                    || miuiHomeOpenBreakCommandPending
+                    || !endedLauncherOpenWallpaperReset.compareAndSet(
+                    marker, null)) {
+                return false;
+            }
+            moduleLog(Log.INFO, TAG,
+                    "Suppressed ended launcher OPEN wallpaper Home reset"
+                            + ", eventId=" + inputIdentity.eventId
+                            + ", launcherOpenGeneration="
+                            + inputIdentity.miuiHomeOpenBreakGenerationAtDown
+                            + ", zoom=" + marker.homeZoom);
+            return true;
+        } catch (Throwable throwable) {
+            endedLauncherOpenWallpaperReset.compareAndSet(marker, null);
+            moduleLog(Log.WARN, TAG,
+                    "Failed to validate launcher OPEN wallpaper reset; "
+                            + "preserving Xiaomi cleanup",
+                    throwable);
+            return false;
+        }
     }
 
     protected Object captureMiuiHomeLauncherOpenSnapshotAfterTargetsBound(
@@ -2703,6 +2850,10 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
 
     protected Object observeMiuiHomeReturnHomeWallpaperSet(
             XposedInterface.Chain chain) throws Throwable {
+        if (consumeEndedLauncherOpenWallpaperReset(
+                chain.getThisObject(), chain.getArg(0))) {
+            return null;
+        }
         Object result = chain.proceed();
         MiuiHomeReturnHomeController controller = miuiHomeReturnHomeController;
         if (controller != null) {
@@ -2980,12 +3131,26 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 acceptedIntent.putExtra(EXTRA_INPUT_EDGE, edge);
                 acceptedIntent.putExtra(EXTRA_INPUT_ARBITER_GENERATION,
                         miuiHomeSystemUiInputArbiterGeneration);
+                long openBreakGeneration = miuiHomeOpenBreakGeneration;
+                Object openBreakAnimation = miuiHomeOpenBreakAnimationIdentity;
+                if (!miuiHomeOpenBreakAnimationActive
+                        || miuiHomeOpenBreakGenerationPrepared
+                        || openBreakGeneration == 0L
+                        || openBreakAnimation == null
+                        || miuiHomeOpenBreakGeneration != openBreakGeneration
+                        || miuiHomeOpenBreakAnimationIdentity
+                        != openBreakAnimation
+                        || !miuiHomeOpenBreakAnimationActive) {
+                    openBreakGeneration = 0L;
+                    openBreakAnimation = null;
+                }
                 MiuiHomeAcceptedInputToken inputIdentity =
                         new MiuiHomeAcceptedInputToken(
                                 eventId, event.getDownTime(),
                                 event.getDeviceId(), event.getSource(),
                                 displayId, edge,
-                                miuiHomeSystemUiInputArbiterGeneration);
+                                miuiHomeSystemUiInputArbiterGeneration,
+                                openBreakGeneration, openBreakAnimation);
                 miuiHomeAcceptedInputIdentity.set(inputIdentity);
                 sendAuthenticatedMiuiHomeState(stub.getContext(), acceptedIntent);
                 moduleLog(Log.INFO, TAG, "Published MiuiHome accepted input token"
@@ -2994,7 +3159,9 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                         + ", displayId=" + displayId
                         + ", edge=" + edge
                         + ", generation="
-                        + miuiHomeSystemUiInputArbiterGeneration);
+                        + miuiHomeSystemUiInputArbiterGeneration
+                        + ", launcherOpenGeneration="
+                        + openBreakGeneration);
             } catch (Throwable throwable) {
                 moduleLog(Log.WARN, TAG, "Failed to publish MiuiHome accepted input token; "
                         + "gesture remains fail-closed", throwable);
@@ -3069,6 +3236,7 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
                 publishLegacyRuntimeStatusReply(receiverContext, intent, generation);
                 if (newGeneration) {
                     miuiHomeAcceptedInputIdentity.set(null);
+                    endedLauncherOpenWallpaperReset.set(null);
                     miuiHomeEditingStatePublished = false;
                     refreshMiuiHomeEditingState(
                             receiverContext.getClassLoader(), "systemUiArbiterGeneration");
@@ -3190,6 +3358,7 @@ public abstract class MiuiHomeHookRuntime extends MiuiHomeReturnHomeRuntime {
         miuiHomeSystemUiInputArbiterReady = false;
         miuiHomeSystemUiInputArbiterGeneration = 0L;
         miuiHomeAcceptedInputIdentity.set(null);
+        endedLauncherOpenWallpaperReset.set(null);
         if (receiver == null || receiverContext == null) {
             return;
         }

--- a/app/src/test/java/dev/codex/miuibackgesturehook/hooks/core/EndedLauncherOpenWallpaperResetTest.kt
+++ b/app/src/test/java/dev/codex/miuibackgesturehook/hooks/core/EndedLauncherOpenWallpaperResetTest.kt
@@ -1,0 +1,24 @@
+package dev.codex.miuibackgesturehook.hooks.core
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EndedLauncherOpenWallpaperResetTest {
+    @Test
+    fun matchesOnlyTheExactWallpaperHomeCommand() {
+        val wallpaper = Any()
+        val marker = HookRuntimeCore.EndedLauncherOpenWallpaperReset(
+            null,
+            0,
+            null,
+            null,
+            wallpaper,
+            1f,
+        )
+
+        assertTrue(marker.matchesCommand(wallpaper, 1f))
+        assertFalse(marker.matchesCommand(Any(), 1f))
+        assertFalse(marker.matchesCommand(wallpaper, 1.14f))
+    }
+}


### PR DESCRIPTION
“提高模块稳定性，优化模块流畅度”